### PR TITLE
chore: update all repo references to doo-iconik

### DIFF
--- a/extract-icons.mjs
+++ b/extract-icons.mjs
@@ -3,8 +3,11 @@
  * Uses a more robust approach to extract function bodies
  */
 import { readFileSync, writeFileSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
-const source = readFileSync('/Users/Vernes/ajentik.com/node_modules/doodle-icons/build/index.es.js', 'utf-8');
+const source = readFileSync(join(__dirname, '../ajentik.com/node_modules/doodle-icons/build/index.es.js'), 'utf-8');
 
 // Step 1: Find all "var SvgXxx = function (props)" declarations
 const declRegex = /var (Svg\w+(?:\$\d+)?)\s*=\s*function\s*\(props\)\s*\{/g;
@@ -147,8 +150,8 @@ console.log(`\nTotal: ${totalMapped} mapped, ${totalMissing} missing`);
 console.log(`Final icon count: ${Object.keys(finalIcons).length}`);
 
 // Write outputs
-writeFileSync('/Users/Vernes/svelte-doodle-icons/icon-data-raw.json', JSON.stringify(finalIcons, null, 2));
-writeFileSync('/Users/Vernes/svelte-doodle-icons/icon-names.json', JSON.stringify(Object.keys(finalIcons).sort(), null, 2));
+writeFileSync(join(__dirname, 'icon-data-raw.json'), JSON.stringify(finalIcons, null, 2));
+writeFileSync(join(__dirname, 'icon-names.json'), JSON.stringify(Object.keys(finalIcons).sort(), null, 2));
 
 // Summary by category
 const summary = {};
@@ -162,5 +165,5 @@ for (const [cat, names] of Object.entries(summary).sort()) {
   console.log(`  ${cat} (${names.length}): ${names.slice(0, 5).join(', ')}...`);
 }
 
-writeFileSync('/Users/Vernes/svelte-doodle-icons/categories.json', JSON.stringify(summary, null, 2));
+writeFileSync(join(__dirname, 'categories.json'), JSON.stringify(summary, null, 2));
 console.log('\nDone!');

--- a/merge-healthcare.mjs
+++ b/merge-healthcare.mjs
@@ -4,8 +4,12 @@
 import { readFileSync, writeFileSync } from 'fs';
 
 // Read existing icon data
-const mainIcons = JSON.parse(readFileSync('/Users/Vernes/svelte-doodle-icons/icon-data-raw.json', 'utf-8'));
-const healthcareIcons = JSON.parse(readFileSync('/Users/Vernes/svelte-doodle-icons/healthcare-icons.json', 'utf-8'));
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const mainIcons = JSON.parse(readFileSync(join(__dirname, 'icon-data-raw.json'), 'utf-8'));
+const healthcareIcons = JSON.parse(readFileSync(join(__dirname, 'healthcare-icons.json'), 'utf-8'));
 
 console.log(`Main icons: ${Object.keys(mainIcons).length}`);
 console.log(`Healthcare icons: ${Object.keys(healthcareIcons).length}`);
@@ -26,7 +30,7 @@ console.log(`Added: ${added}, Skipped (duplicates): ${skipped}`);
 console.log(`Total icons: ${Object.keys(mainIcons).length}`);
 
 // Write merged data
-writeFileSync('/Users/Vernes/svelte-doodle-icons/icon-data-raw.json', JSON.stringify(mainIcons, null, 2));
+writeFileSync(join(__dirname, 'icon-data-raw.json'), JSON.stringify(mainIcons, null, 2));
 
 // Generate types.ts
 const allNames = Object.keys(mainIcons).sort();
@@ -38,7 +42,7 @@ typesContent += `export type DoodleIconSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl' |
 typesContent += 'export type DoodleIconCategory =\n';
 typesContent += allCategories.map(c => `  | '${c}'`).join('\n') + ';\n';
 
-writeFileSync('/Users/Vernes/svelte-doodle-icons/src/lib/types.ts', typesContent);
+writeFileSync(join(__dirname, 'src/lib/types.ts'), typesContent);
 
 // Generate icon-data.ts
 let dataContent = '// Auto-generated — do not edit manually\n\n';
@@ -65,7 +69,7 @@ for (const name of allNames) {
 
 dataContent += '};\n';
 
-writeFileSync('/Users/Vernes/svelte-doodle-icons/src/lib/icon-data.ts', dataContent);
+writeFileSync(join(__dirname, 'src/lib/icon-data.ts'), dataContent);
 
 console.log(`\nRegenerated types.ts (${allNames.length} names) and icon-data.ts`);
 console.log(`Categories: ${allCategories.join(', ')}`);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,7 +38,7 @@
   "keywords": ["icons", "doodle", "hand-drawn", "healthcare", "ui", "doo-iconik"],
   "repository": {
     "type": "git",
-    "url": "https://github.com/ajentik/svelte-doodle-icons.git",
+    "url": "https://github.com/ajentik/doo-iconik.git",
     "directory": "packages/core"
   }
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -34,7 +34,7 @@
   "keywords": ["icons", "doodle", "hand-drawn", "react", "doo-iconik"],
   "repository": {
     "type": "git",
-    "url": "https://github.com/ajentik/svelte-doodle-icons.git",
+    "url": "https://github.com/ajentik/doo-iconik.git",
     "directory": "packages/react"
   }
 }

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -33,7 +33,7 @@
   "keywords": ["icons", "doodle", "hand-drawn", "svelte", "doo-iconik"],
   "repository": {
     "type": "git",
-    "url": "https://github.com/ajentik/svelte-doodle-icons.git",
+    "url": "https://github.com/ajentik/doo-iconik.git",
     "directory": "packages/svelte"
   }
 }

--- a/packages/vanilla/package.json
+++ b/packages/vanilla/package.json
@@ -28,7 +28,7 @@
   "keywords": ["icons", "doodle", "hand-drawn", "web-components", "custom-elements", "vanilla", "ui", "doo-iconik"],
   "repository": {
     "type": "git",
-    "url": "https://github.com/ajentik/svelte-doodle-icons.git",
+    "url": "https://github.com/ajentik/doo-iconik.git",
     "directory": "packages/vanilla"
   }
 }

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -32,7 +32,7 @@
   "keywords": ["icons", "doodle", "hand-drawn", "vue", "vue3", "ui", "doo-iconik"],
   "repository": {
     "type": "git",
-    "url": "https://github.com/ajentik/svelte-doodle-icons.git",
+    "url": "https://github.com/ajentik/doo-iconik.git",
     "directory": "packages/vue"
   }
 }


### PR DESCRIPTION
## Summary
- Update repository URLs from `svelte-doodle-icons` to `doo-iconik` in all 5 package.json files
- Replace hardcoded absolute paths with `__dirname`-relative paths in `extract-icons.mjs` and `merge-healthcare.mjs`
- Update git remote URL

## Test plan
- [ ] Verify `npm install` resolves workspace dependencies
- [ ] Run `node generate.mjs` to confirm relative paths work

🤖 Generated with [Claude Code](https://claude.com/claude-code)