### PR TITLE
fix: replace workspace:* with file:../core for git dep compat

### DIFF
--- a/packages/alpine/package.json
+++ b/packages/alpine/package.json
@@ -19,7 +19,7 @@
     "build": "tsup src/index.ts --format esm,cjs,iife --global-name DooIconikAlpine --dts"
   },
   "dependencies": {
-    "@doo-iconik/core": "workspace:*"
+    "@doo-iconik/core": "file:../core"
   },
   "peerDependencies": {
     "alpinejs": "^3.0.0"

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -7,7 +7,7 @@
     "build": "ng-packagr -p ng-package.json"
   },
   "dependencies": {
-    "@doo-iconik/core": "workspace:*"
+    "@doo-iconik/core": "file:../core"
   },
   "peerDependencies": {
     "@angular/core": ">=16.0.0",

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -10,7 +10,7 @@
   },
   "files": ["src"],
   "dependencies": {
-    "@doo-iconik/core": "workspace:*"
+    "@doo-iconik/core": "file:../core"
   },
   "peerDependencies": {
     "astro": "^3.0.0 || ^4.0.0"

--- a/packages/lit/package.json
+++ b/packages/lit/package.json
@@ -19,7 +19,7 @@
     "build": "tsup src/index.ts --format esm,cjs --dts"
   },
   "dependencies": {
-    "@doo-iconik/core": "workspace:*"
+    "@doo-iconik/core": "file:../core"
   },
   "peerDependencies": {
     "lit": "^3.0.0"

--- a/packages/preact/package.json
+++ b/packages/preact/package.json
@@ -20,7 +20,7 @@
     "build": "tsup src/index.tsx --format esm,cjs --dts"
   },
   "dependencies": {
-    "@doo-iconik/core": "workspace:*"
+    "@doo-iconik/core": "file:../core"
   },
   "peerDependencies": {
     "preact": "^10.0.0"

--- a/packages/qwik/package.json
+++ b/packages/qwik/package.json
@@ -20,7 +20,7 @@
     "build": "tsup src/index.tsx --format esm,cjs --dts --external @builder.io/qwik"
   },
   "dependencies": {
-    "@doo-iconik/core": "workspace:*"
+    "@doo-iconik/core": "file:../core"
   },
   "peerDependencies": {
     "@builder.io/qwik": "^1.5.0 || ^2.0.0"

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -20,7 +20,7 @@
     "build": "tsup src/index.tsx --format esm,cjs --dts"
   },
   "dependencies": {
-    "@doo-iconik/core": "workspace:*"
+    "@doo-iconik/core": "file:../core"
   },
   "peerDependencies": {
     "react": "^18.0.0 || ^19.0.0",

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -20,7 +20,7 @@
     "build": "tsup src/index.tsx --format esm,cjs --dts"
   },
   "dependencies": {
-    "@doo-iconik/core": "workspace:*"
+    "@doo-iconik/core": "file:../core"
   },
   "peerDependencies": {
     "solid-js": "^1.7.0"

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -20,7 +20,7 @@
     "build": "svelte-package -i src -o dist"
   },
   "dependencies": {
-    "@doo-iconik/core": "workspace:*"
+    "@doo-iconik/core": "file:../core"
   },
   "peerDependencies": {
     "svelte": "^5.0.0"

--- a/packages/vanilla/package.json
+++ b/packages/vanilla/package.json
@@ -19,7 +19,7 @@
     "build": "tsup src/index.ts --format esm,cjs,iife --global-name DooIconik --dts"
   },
   "dependencies": {
-    "@doo-iconik/core": "workspace:*"
+    "@doo-iconik/core": "file:../core"
   },
   "devDependencies": {
     "tsup": "^8.0.0",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -19,7 +19,7 @@
     "build": "tsup src/index.ts --format esm,cjs --dts"
   },
   "dependencies": {
-    "@doo-iconik/core": "workspace:*"
+    "@doo-iconik/core": "file:../core"
   },
   "peerDependencies": {
     "vue": "^3.3.0"


### PR DESCRIPTION
## Summary
- Replace `workspace:*` with `file:../core` in all 11 subpackage `package.json` files
- Fixes `EUNSUPPORTEDPROTOCOL` error when installing as a GitHub git dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)