### PR TITLE
fix: update icon count to 595 in docs and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # doo-iconik
 
-592+ hand-drawn doodle style SVG icons for any framework.
+595 hand-drawn doodle style SVG icons for any framework.
 
 ## Packages
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>doo-iconik | 592+ hand-drawn doodle-style SVG icons</title>
+  <title>doo-iconik | 595 hand-drawn doodle-style SVG icons</title>
   <style>
     :root {
       --bg-base: #0a0a0f;
@@ -506,7 +506,7 @@
 
   <header class="header">
     <h1>doo-iconik</h1>
-    <p>592+ hand-drawn doodle-style SVG icons for any framework</p>
+    <p>595 hand-drawn doodle-style SVG icons for any framework</p>
     <a href="https://github.com/ajentik/doo-iconik" class="github-link" target="_blank" rel="noopener noreferrer">
       <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor">
         <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>


### PR DESCRIPTION
## Summary
- Updates icon count from "592+" to "595" in docs/index.html title and header
- Updates icon count in README.md

## Test plan
- [ ] Verify GitHub Pages deploys with updated count
- [ ] Check ajentik.github.io/doo-iconik shows "595"

🤖 Generated with [Claude Code](https://claude.com/claude-code)