### PR TITLE
ci: auto-sync icon updates to ajentik.sg via Cloudflare

### DIFF
--- a/.github/workflows/sync-icons-to-ajentik.yml
+++ b/.github/workflows/sync-icons-to-ajentik.yml
@@ -1,0 +1,22 @@
+name: Sync Icons to ajentik-svelte
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'icon-data-raw.json'
+      - 'packages/core/src/icon-data.ts'
+      - 'categories.json'
+  workflow_dispatch:
+
+jobs:
+  trigger-ajentik-rebuild:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger ajentik-svelte icon sync
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.CROSS_REPO_PAT }}
+          repository: ajentik/ajentik-svelte
+          event-type: icon-data-updated
+          client-payload: '{"ref": "${{ github.sha }}", "repo": "doo-iconik"}'


### PR DESCRIPTION
## Summary
- Adds workflow to trigger ajentik-svelte rebuild when icon data changes
- Uses `repository_dispatch` to notify ajentik-svelte repo
- ajentik-svelte already has matching `sync-icons.yml` workflow that updates the dependency and pushes to main, triggering Cloudflare Pages deploy

## Flow
```
doo-iconik push → sync-icons-to-ajentik.yml → repository_dispatch → ajentik-svelte sync-icons.yml → npm update → push to main → Cloudflare Pages deploy
```

## Test plan
- [ ] Verify CROSS_REPO_PAT secret is set
- [ ] Test with workflow_dispatch manually
- [ ] Confirm ajentik.sg/icons updates after icon changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)