### PR TITLE
fix: add root exports for svelte-doodle-icons compat

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,4 @@
+// Type definitions for svelte-doodle-icons compatibility
+export { DooIconikName as DoodleIconName, DooIconikSize as DoodleIconSize, DooIconikCategory as DoodleIconCategory } from './packages/core/src/types.js';
+export { iconData } from './packages/core/src/icon-data.js';
+export { default as DoodleIcon } from './packages/svelte/src/DooIconik.svelte';

--- a/index.js
+++ b/index.js
@@ -1,0 +1,5 @@
+// Compatibility entry point for svelte-doodle-icons consumers
+// Re-exports with legacy DoodleIcon naming
+
+export { default as DoodleIcon } from './packages/svelte/src/DooIconik.svelte';
+export { iconData } from './packages/core/src/icon-data.js';

--- a/package.json
+++ b/package.json
@@ -2,6 +2,17 @@
   "name": "doo-iconik",
   "private": true,
   "type": "module",
+  "svelte": "./packages/svelte/src/DooIconik.svelte",
+  "main": "./index.js",
+  "types": "./index.d.ts",
+  "exports": {
+    ".": {
+      "svelte": "./packages/svelte/src/DooIconik.svelte",
+      "types": "./index.d.ts",
+      "import": "./index.js",
+      "default": "./index.js"
+    }
+  },
   "workspaces": ["packages/*"],
   "scripts": {
     "generate": "node generate.mjs",


### PR DESCRIPTION
## Summary
- Adds `exports`, `svelte`, `main`, `types` fields to root package.json
- Creates `index.js` and `index.d.ts` with compatibility re-exports
- Maps `DoodleIcon` → `DooIconik` and `DoodleIconName` → `DooIconikName`
- Fixes Vite build failure in ajentik-svelte: `Failed to resolve entry for package "svelte-doodle-icons"`

## Test plan
- [ ] ajentik-svelte build should succeed after syncing this update
- [ ] ajentik.sg/icons should render icons correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)