### PR TITLE
fix: named import resolution for svelte-doodle-icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,12 +2,10 @@
   "name": "doo-iconik",
   "private": true,
   "type": "module",
-  "svelte": "./DoodleIcon.svelte",
   "main": "./index.js",
   "types": "./index.d.ts",
   "exports": {
     ".": {
-      "svelte": "./DoodleIcon.svelte",
       "types": "./index.d.ts",
       "import": "./index.js",
       "default": "./index.js"


### PR DESCRIPTION
## Summary
- Removes `svelte` export condition that was shadowing `import` condition
- `import { DoodleIcon, iconData }` now correctly resolves to `index.js`
- Fixes: `"iconData" is not exported by "DoodleIcon.svelte"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)