### PR TITLE
fix(ci): correct icon count grep pattern for TypeScript format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Verify icon counts match across frameworks
         run: |
           RAW_COUNT=$(node -e "const d=JSON.parse(require('fs').readFileSync('icon-data-raw.json','utf8')); console.log(Object.keys(d).length)")
-          CORE_COUNT=$(grep -c '"viewBox"' packages/core/src/icon-data.ts)
+          CORE_COUNT=$(grep -c 'viewBox: "' packages/core/src/icon-data.ts)
           FLUTTER_COUNT=$(grep -c "viewBox:" packages/flutter/lib/src/icon_data.dart)
           LARAVEL_COUNT=$(node -e "const d=JSON.parse(require('fs').readFileSync('packages/laravel/data/icon-data.json','utf8')); console.log(Object.keys(d).length)")
           RAILS_COUNT=$(node -e "const d=JSON.parse(require('fs').readFileSync('packages/rails/data/icon-data.json','utf8')); console.log(Object.keys(d).length)")


### PR DESCRIPTION
## Summary

- Fix pre-existing CI failure: `grep -c '"viewBox"'` matched JSON-style quoted keys but `icon-data.ts` uses TypeScript `viewBox: "0 0 24 24"` (unquoted key)
- Changed pattern to `viewBox: "` which matches all 595 data entries but excludes the `interface IconData { viewBox: string; }` definition

This bug has been causing CI to fail on every push/PR since the CI workflow was added.

## Test plan

- [ ] CI passes on this PR (self-verifying)

🤖 Generated with [Claude Code](https://claude.com/claude-code)