### PR TITLE
chore(astro): extend peerDependencies to support Astro 5 and 6

### DIFF
--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -22,7 +22,7 @@
     "@doo-iconik/core": "file:../core"
   },
   "peerDependencies": {
-    "astro": "^3.0.0 || ^4.0.0"
+    "astro": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0"
   },
   "devDependencies": {
     "astro": "^6.0.8",


### PR DESCRIPTION
Extends Astro peerDependencies from `^3.0.0 || ^4.0.0` to `^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0` after merging dependabot Astro 6 bump.