### PR TITLE
feat: add README badges and unit test suite (47 tests)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
 
       - run: npm run build --workspace=packages/core
 
+      - name: Run tests
+        run: npx vitest run
+
       - name: Verify icon counts match across frameworks
         run: |
           RAW_COUNT=$(node -e "const d=JSON.parse(require('fs').readFileSync('icon-data-raw.json','utf8')); console.log(Object.keys(d).length)")

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # doo-iconik
 
+[![CI](https://github.com/ajentik/doo-iconik/actions/workflows/ci.yml/badge.svg)](https://github.com/ajentik/doo-iconik/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Icons](https://img.shields.io/badge/icons-595-blueviolet)](https://ajentik.github.io/doo-iconik/)
+[![Frameworks](https://img.shields.io/badge/frameworks-15-blue)](https://github.com/ajentik/doo-iconik#packages)
+
 595 hand-drawn doodle style SVG icons for any framework.
 
 ## Packages

--- a/package.json
+++ b/package.json
@@ -2,16 +2,23 @@
   "name": "doo-iconik",
   "private": true,
   "type": "module",
-  "workspaces": ["packages/*"],
+  "workspaces": [
+    "packages/*"
+  ],
   "scripts": {
     "generate": "node generate.mjs",
     "build": "npm run generate && npm run build --workspaces",
-    "build:core": "npm run build --workspace=packages/core"
+    "build:core": "npm run build --workspace=packages/core",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "engines": {
     "node": ">=24"
   },
   "devDependencies": {
-    "typescript": "^5.0.0"
+    "@vitest/coverage-v8": "^4.1.0",
+    "typescript": "^5.0.0",
+    "vitest": "^4.1.0"
   }
 }

--- a/packages/alpine/README.md
+++ b/packages/alpine/README.md
@@ -1,5 +1,7 @@
 # @doo-iconik/alpine
 
+[![npm version](https://img.shields.io/npm/v/@doo-iconik/alpine.svg)](https://www.npmjs.com/package/@doo-iconik/alpine)
+
 Alpine.js plugin: 595 hand-drawn doodle-style SVG icons for Alpine.js 3.
 
 Part of [doo-iconik](https://github.com/ajentik/doo-iconik).

--- a/packages/angular/README.md
+++ b/packages/angular/README.md
@@ -1,5 +1,7 @@
 # @doo-iconik/angular
 
+[![npm version](https://img.shields.io/npm/v/@doo-iconik/angular.svg)](https://www.npmjs.com/package/@doo-iconik/angular)
+
 Angular component library: 595 hand-drawn doodle-style SVG icons for Angular 16+.
 
 Part of [doo-iconik](https://github.com/ajentik/doo-iconik).

--- a/packages/astro/README.md
+++ b/packages/astro/README.md
@@ -1,5 +1,7 @@
 # @doo-iconik/astro
 
+[![npm version](https://img.shields.io/npm/v/@doo-iconik/astro.svg)](https://www.npmjs.com/package/@doo-iconik/astro)
+
 Astro component library: 595 hand-drawn doodle-style SVG icons for Astro 3/4.
 
 Part of [doo-iconik](https://github.com/ajentik/doo-iconik).

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,5 +1,7 @@
 # @doo-iconik/core
 
+[![npm version](https://img.shields.io/npm/v/@doo-iconik/core.svg)](https://www.npmjs.com/package/@doo-iconik/core)
+
 Framework-agnostic shared icon data and utilities: 595 hand-drawn doodle-style SVG icons.
 
 Part of [doo-iconik](https://github.com/ajentik/doo-iconik).

--- a/packages/core/src/__tests__/icon-data.test.ts
+++ b/packages/core/src/__tests__/icon-data.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { iconData } from '../icon-data.js';
+
+describe('iconData', () => {
+  const iconNames = Object.keys(iconData);
+
+  it('has 595 icons', () => {
+    expect(iconNames).toHaveLength(595);
+  });
+
+  it('every icon has a viewBox string matching /^\\d+ \\d+ \\d+ \\d+$/', () => {
+    for (const name of iconNames) {
+      expect(iconData[name].viewBox).toMatch(/^\d+ \d+ \d+ \d+$/);
+    }
+  });
+
+  it('every icon has at least one path', () => {
+    for (const name of iconNames) {
+      expect(iconData[name].paths.length).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  it('every path is a non-empty string', () => {
+    for (const name of iconNames) {
+      for (const path of iconData[name].paths) {
+        expect(typeof path).toBe('string');
+        expect(path.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it('circles have cx, cy, r (number) when present', () => {
+    for (const name of iconNames) {
+      const icon = iconData[name];
+      if (icon.circles) {
+        for (const circle of icon.circles) {
+          expect(typeof circle.cx).toBe('number');
+          expect(typeof circle.cy).toBe('number');
+          expect(typeof circle.r).toBe('number');
+        }
+      }
+    }
+  });
+
+  it('lines have x1, y1, x2, y2 (number) when present', () => {
+    for (const name of iconNames) {
+      const icon = iconData[name];
+      if (icon.lines) {
+        for (const line of icon.lines) {
+          expect(typeof line.x1).toBe('number');
+          expect(typeof line.y1).toBe('number');
+          expect(typeof line.x2).toBe('number');
+          expect(typeof line.y2).toBe('number');
+        }
+      }
+    }
+  });
+
+  it('stroke is boolean when present', () => {
+    for (const name of iconNames) {
+      const icon = iconData[name];
+      if (icon.stroke !== undefined) {
+        expect(typeof icon.stroke).toBe('boolean');
+      }
+    }
+  });
+
+  it('icon names are kebab-case', () => {
+    for (const name of iconNames) {
+      expect(name).toMatch(/^[a-z0-9]+(-[a-z0-9]+)*$/);
+    }
+  });
+});

--- a/packages/core/src/__tests__/utils.test.ts
+++ b/packages/core/src/__tests__/utils.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from 'vitest';
+import {
+  escapeAttr,
+  resolveSize,
+  sizeMap,
+  buildTransform,
+  buildAnimationClasses,
+  buildVariantClass,
+} from '../utils.js';
+
+describe('escapeAttr', () => {
+  it('escapes ampersand', () => {
+    expect(escapeAttr('a&b')).toBe('a&amp;b');
+  });
+
+  it('escapes double quote', () => {
+    expect(escapeAttr('a"b')).toBe('a&quot;b');
+  });
+
+  it('escapes single quote', () => {
+    expect(escapeAttr("a'b")).toBe('a&#39;b');
+  });
+
+  it('escapes less-than', () => {
+    expect(escapeAttr('a<b')).toBe('a&lt;b');
+  });
+
+  it('escapes greater-than', () => {
+    expect(escapeAttr('a>b')).toBe('a&gt;b');
+  });
+
+  it('returns empty string unchanged', () => {
+    expect(escapeAttr('')).toBe('');
+  });
+
+  it('returns string with no special chars unchanged', () => {
+    expect(escapeAttr('hello world')).toBe('hello world');
+  });
+});
+
+describe('resolveSize', () => {
+  it('resolves xs to 12', () => {
+    expect(resolveSize('xs')).toBe(12);
+  });
+
+  it('resolves sm to 16', () => {
+    expect(resolveSize('sm')).toBe(16);
+  });
+
+  it('resolves md to 24', () => {
+    expect(resolveSize('md')).toBe(24);
+  });
+
+  it('resolves lg to 32', () => {
+    expect(resolveSize('lg')).toBe(32);
+  });
+
+  it('resolves xl to 48', () => {
+    expect(resolveSize('xl')).toBe(48);
+  });
+
+  it('resolves 2xl to 64', () => {
+    expect(resolveSize('2xl')).toBe(64);
+  });
+
+  it('passes through numeric size', () => {
+    expect(resolveSize(128)).toBe(128);
+  });
+
+  it('defaults unknown string to 24', () => {
+    expect(resolveSize('unknown' as any)).toBe(24);
+  });
+});
+
+describe('sizeMap', () => {
+  it('has exactly 6 entries', () => {
+    expect(Object.keys(sizeMap)).toHaveLength(6);
+  });
+});
+
+describe('buildTransform', () => {
+  it('returns undefined when no flips', () => {
+    expect(buildTransform(false, false)).toBeUndefined();
+  });
+
+  it('returns scaleX(-1) for flipH', () => {
+    expect(buildTransform(true, false)).toBe('scaleX(-1)');
+  });
+
+  it('returns scaleY(-1) for flipV', () => {
+    expect(buildTransform(false, true)).toBe('scaleY(-1)');
+  });
+
+  it('returns both transforms for flipH and flipV', () => {
+    expect(buildTransform(true, true)).toBe('scaleX(-1) scaleY(-1)');
+  });
+});
+
+describe('buildAnimationClasses', () => {
+  it('returns empty string with no animations', () => {
+    expect(buildAnimationClasses(false, false, false)).toBe('');
+  });
+
+  it('returns spin class when spin is true', () => {
+    expect(buildAnimationClasses(true, false, false)).toBe('doo-iconik-spin');
+  });
+
+  it('returns multiple classes for multiple booleans', () => {
+    const result = buildAnimationClasses(true, true, true);
+    expect(result).toBe('doo-iconik-spin doo-iconik-pulse doo-iconik-bounce');
+  });
+
+  it('animation prop overrides boolean flags', () => {
+    const result = buildAnimationClasses(true, true, true, 'wiggle');
+    expect(result).toBe('doo-iconik-wiggle');
+  });
+});
+
+describe('buildVariantClass', () => {
+  it('returns empty string for undefined', () => {
+    expect(buildVariantClass(undefined)).toBe('');
+  });
+
+  it('returns empty string for default', () => {
+    expect(buildVariantClass('default')).toBe('');
+  });
+
+  it('returns doo-iconik-glow for glow', () => {
+    expect(buildVariantClass('glow')).toBe('doo-iconik-glow');
+  });
+
+  it('returns doo-iconik-neon for neon', () => {
+    expect(buildVariantClass('neon')).toBe('doo-iconik-neon');
+  });
+});

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['src/__tests__/**/*.test.ts'],
+  },
+});

--- a/packages/flutter/README.md
+++ b/packages/flutter/README.md
@@ -1,5 +1,7 @@
 # doo_iconik
 
+[![pub version](https://img.shields.io/pub/v/doo_iconik.svg)](https://pub.dev/packages/doo_iconik)
+
 Flutter widget library: 595 hand-drawn doodle-style SVG icons for Flutter 3.10+.
 
 Part of [doo-iconik](https://github.com/ajentik/doo-iconik).

--- a/packages/laravel/README.md
+++ b/packages/laravel/README.md
@@ -1,5 +1,7 @@
 # ajentik/doo-iconik-laravel
 
+[![Packagist Version](https://img.shields.io/packagist/v/ajentik/doo-iconik-laravel.svg)](https://packagist.org/packages/ajentik/doo-iconik-laravel)
+
 Laravel Blade component: 595 hand-drawn doodle-style SVG icons for Laravel 10/11/12.
 
 Part of [doo-iconik](https://github.com/ajentik/doo-iconik).

--- a/packages/lit/README.md
+++ b/packages/lit/README.md
@@ -1,5 +1,7 @@
 # @doo-iconik/lit
 
+[![npm version](https://img.shields.io/npm/v/@doo-iconik/lit.svg)](https://www.npmjs.com/package/@doo-iconik/lit)
+
 Lit web component: 595 hand-drawn doodle-style SVG icons for Lit 3.
 
 Part of [doo-iconik](https://github.com/ajentik/doo-iconik).

--- a/packages/preact/README.md
+++ b/packages/preact/README.md
@@ -1,5 +1,7 @@
 # @doo-iconik/preact
 
+[![npm version](https://img.shields.io/npm/v/@doo-iconik/preact.svg)](https://www.npmjs.com/package/@doo-iconik/preact)
+
 Preact component library: 595 hand-drawn doodle-style SVG icons for Preact 10.
 
 Part of [doo-iconik](https://github.com/ajentik/doo-iconik).

--- a/packages/qwik/README.md
+++ b/packages/qwik/README.md
@@ -1,5 +1,7 @@
 # @doo-iconik/qwik
 
+[![npm version](https://img.shields.io/npm/v/@doo-iconik/qwik.svg)](https://www.npmjs.com/package/@doo-iconik/qwik)
+
 Qwik component library: 595 hand-drawn doodle-style SVG icons for Qwik.
 
 Part of [doo-iconik](https://github.com/ajentik/doo-iconik).

--- a/packages/rails/README.md
+++ b/packages/rails/README.md
@@ -1,5 +1,7 @@
 # doo_iconik
 
+[![Gem Version](https://img.shields.io/gem/v/doo_iconik.svg)](https://rubygems.org/gems/doo_iconik)
+
 Rails helper gem: 595 hand-drawn doodle-style SVG icons for Rails 6+.
 
 Part of [doo-iconik](https://github.com/ajentik/doo-iconik).

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,5 +1,7 @@
 # @doo-iconik/react
 
+[![npm version](https://img.shields.io/npm/v/@doo-iconik/react.svg)](https://www.npmjs.com/package/@doo-iconik/react)
+
 React component library: 595 hand-drawn doodle-style SVG icons for React 18/19.
 
 Part of [doo-iconik](https://github.com/ajentik/doo-iconik).

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -21,7 +21,9 @@
       "default": "./dist/index.mjs"
     }
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsup src/index.tsx --format esm,cjs --dts"
   },
@@ -33,11 +35,20 @@
     "react-dom": "^18.0.0 || ^19.0.0"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
     "@types/react": "^19.2.14",
+    "jsdom": "^29.0.1",
     "tsup": "^8.0.0",
     "typescript": "^5.0.0"
   },
-  "keywords": ["icons", "doodle", "hand-drawn", "react", "doo-iconik"],
+  "keywords": [
+    "icons",
+    "doodle",
+    "hand-drawn",
+    "react",
+    "doo-iconik"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/ajentik/doo-iconik.git",

--- a/packages/react/src/__tests__/DooIconik.test.tsx
+++ b/packages/react/src/__tests__/DooIconik.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { DooIconik } from '../DooIconik';
+
+describe('DooIconik', () => {
+  it('renders an SVG element', () => {
+    const { container } = render(<DooIconik name="heart" />);
+    const svg = container.querySelector('svg');
+    expect(svg).not.toBeNull();
+  });
+
+  it('returns null for unknown icon name', () => {
+    const { container } = render(<DooIconik name={'nonexistent-icon' as any} />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('applies default size (24px)', () => {
+    const { container } = render(<DooIconik name="heart" />);
+    const svg = container.querySelector('svg')!;
+    expect(svg.getAttribute('width')).toBe('24');
+    expect(svg.getAttribute('height')).toBe('24');
+  });
+
+  it('applies named size (lg = 32)', () => {
+    const { container } = render(<DooIconik name="heart" size="lg" />);
+    const svg = container.querySelector('svg')!;
+    expect(svg.getAttribute('width')).toBe('32');
+    expect(svg.getAttribute('height')).toBe('32');
+  });
+
+  it('applies numeric size (64)', () => {
+    const { container } = render(<DooIconik name="heart" size={64} />);
+    const svg = container.querySelector('svg')!;
+    expect(svg.getAttribute('width')).toBe('64');
+    expect(svg.getAttribute('height')).toBe('64');
+  });
+
+  it('is aria-hidden by default', () => {
+    const { container } = render(<DooIconik name="heart" />);
+    const svg = container.querySelector('svg')!;
+    expect(svg.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('applies aria-label and role="img" when ariaLabel set', () => {
+    const { container } = render(<DooIconik name="heart" ariaLabel="Heart icon" />);
+    const svg = container.querySelector('svg')!;
+    expect(svg.getAttribute('aria-label')).toBe('Heart icon');
+    expect(svg.getAttribute('role')).toBe('img');
+    expect(svg.getAttribute('aria-hidden')).toBeNull();
+  });
+
+  it('applies animation class (spin)', () => {
+    const { container } = render(<DooIconik name="heart" spin />);
+    const svg = container.querySelector('svg')!;
+    expect(svg.classList.contains('doo-iconik-spin')).toBe(true);
+  });
+
+  it('applies variant class (glow)', () => {
+    const { container } = render(<DooIconik name="heart" variant="glow" />);
+    const svg = container.querySelector('svg')!;
+    expect(svg.classList.contains('doo-iconik-glow')).toBe(true);
+  });
+
+  it('applies transform for flipHorizontal', () => {
+    const { container } = render(<DooIconik name="heart" flipHorizontal />);
+    const svg = container.querySelector('svg')!;
+    expect(svg.style.transform).toBe('scaleX(-1)');
+  });
+
+  it('renders path elements', () => {
+    const { container } = render(<DooIconik name="heart" />);
+    const paths = container.querySelectorAll('path');
+    expect(paths.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/packages/react/vitest.config.ts
+++ b/packages/react/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+export default defineConfig({
+  resolve: {
+    alias: [
+      {
+        find: '@doo-iconik/core',
+        replacement: path.resolve(__dirname, '../core/src/index.ts'),
+      },
+    ],
+  },
+  test: {
+    include: ['src/__tests__/**/*.test.tsx'],
+    environment: 'jsdom',
+  },
+});

--- a/packages/solid/README.md
+++ b/packages/solid/README.md
@@ -1,5 +1,7 @@
 # @doo-iconik/solid
 
+[![npm version](https://img.shields.io/npm/v/@doo-iconik/solid.svg)](https://www.npmjs.com/package/@doo-iconik/solid)
+
 SolidJS component library: 595 hand-drawn doodle-style SVG icons for SolidJS.
 
 Part of [doo-iconik](https://github.com/ajentik/doo-iconik).

--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -1,5 +1,7 @@
 # @doo-iconik/svelte
 
+[![npm version](https://img.shields.io/npm/v/@doo-iconik/svelte.svg)](https://www.npmjs.com/package/@doo-iconik/svelte)
+
 Svelte component library: 595 hand-drawn doodle-style SVG icons for Svelte 5.
 
 Part of [doo-iconik](https://github.com/ajentik/doo-iconik).

--- a/packages/vanilla/README.md
+++ b/packages/vanilla/README.md
@@ -1,5 +1,7 @@
 # @doo-iconik/vanilla
 
+[![npm version](https://img.shields.io/npm/v/@doo-iconik/vanilla.svg)](https://www.npmjs.com/package/@doo-iconik/vanilla)
+
 Vanilla JS / Web Components: 595 hand-drawn doodle-style SVG icons for Vanilla JS.
 
 Part of [doo-iconik](https://github.com/ajentik/doo-iconik).

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -1,5 +1,7 @@
 # @doo-iconik/vue
 
+[![npm version](https://img.shields.io/npm/v/@doo-iconik/vue.svg)](https://www.npmjs.com/package/@doo-iconik/vue)
+
 Vue component library: 595 hand-drawn doodle-style SVG icons for Vue 3.
 
 Part of [doo-iconik](https://github.com/ajentik/doo-iconik).

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    projects: [
+      'packages/core/vitest.config.ts',
+      'packages/react/vitest.config.ts',
+    ],
+  },
+});


### PR DESCRIPTION
## Summary

- **Badges**: CI, license, icon count, framework badges on root README; npm/pub/gem version badges on all 15 per-package READMEs
- **Tests**: Vitest 4 setup with 47 tests across 3 files (592ms runtime)
  - Core utilities: `escapeAttr`, `resolveSize`, `buildTransform`, `buildAnimationClasses`, `buildVariantClass`
  - Icon data integrity: 595 icons validated for structure, naming, types
  - React component: rendering, sizes, a11y, animations, variants, flips
- **CI**: Added `npx vitest run` step to CI workflow

## Test plan

- [ ] `npx vitest run` — 47 tests pass
- [ ] CI passes with new test step
- [ ] Badges render correctly on GitHub README

🤖 Generated with [Claude Code](https://claude.com/claude-code)