### PR TITLE
chore: rename npm scope from @doo-iconik to @ajentik

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,7 +6,7 @@ labels: bug
 
 ## Package
 
-Which package? (e.g., `@doo-iconik/react`, `@doo-iconik/vue`, `doo_iconik` gem)
+Which package? (e.g., `@ajentik/doo-iconik-react`, `@ajentik/doo-iconik-vue`, `doo_iconik` gem)
 
 ## Version
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,24 +36,69 @@ jobs:
       - name: Build all packages
         run: npm run build --workspaces
 
+      - name: Verify icon counts
+        run: |
+          RAW_COUNT=$(node -e "const d=JSON.parse(require('fs').readFileSync('icon-data-raw.json','utf8')); console.log(Object.keys(d).length)")
+          CORE_COUNT=$(grep -c 'viewBox: "' packages/core/src/icon-data.ts)
+          echo "Raw: $RAW_COUNT, Core: $CORE_COUNT"
+          if [ "$CORE_COUNT" != "$RAW_COUNT" ]; then
+            echo "::error::Icon count mismatch: core=$CORE_COUNT raw=$RAW_COUNT"
+            exit 1
+          fi
+
       - name: Run tests
         run: npx vitest run
+
+      - name: Verify version sync
+        if: github.event_name == 'release'
+        run: |
+          TAG="${GITHUB_REF#refs/tags/v}"
+          echo "Release tag version: $TAG"
+          FAIL=0
+          for pkg in packages/{core,react,vue,svelte,angular,solid,lit,preact,qwik,alpine,vanilla,astro}/package.json; do
+            VER=$(node -e "console.log(JSON.parse(require('fs').readFileSync('$pkg','utf8')).version)")
+            if [ "$VER" != "$TAG" ]; then
+              echo "::error::$pkg version ($VER) != tag v$TAG"
+              FAIL=1
+            fi
+          done
+          if [ "$FAIL" -eq 1 ]; then exit 1; fi
+
+      - name: Rewrite core dependency for publish
+        run: |
+          CORE_VER=$(node -e "console.log(JSON.parse(require('fs').readFileSync('packages/core/package.json','utf8')).version)")
+          echo "Core version: $CORE_VER"
+          for pkg in react vue svelte angular solid lit preact qwik alpine vanilla astro; do
+            FILE="packages/$pkg/package.json"
+            node -e "
+              const fs = require('fs');
+              const p = JSON.parse(fs.readFileSync('$FILE', 'utf8'));
+              if (p.dependencies && p.dependencies['@ajentik/doo-iconik'] && p.dependencies['@ajentik/doo-iconik'].startsWith('file:')) {
+                p.dependencies['@ajentik/doo-iconik'] = '^' + '$CORE_VER';
+                fs.writeFileSync('$FILE', JSON.stringify(p, null, 2) + '\n');
+                console.log('Rewrote: ' + '$FILE');
+              }
+            "
+          done
 
       - name: Publish packages
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           DRY_RUN: ${{ inputs.dry-run }}
         run: |
-          DRYRUN=""
-          if [ "$DRY_RUN" = "true" ]; then
-            DRYRUN="--dry-run"
-          fi
+          FLAGS="--access public --provenance"
+          if [ "$DRY_RUN" = "true" ]; then FLAGS="$FLAGS --dry-run"; fi
 
           FAILED=""
           for pkg in core react vue svelte angular solid lit preact qwik alpine vanilla astro; do
-            echo "Publishing @doo-iconik/$pkg..."
-            if ! npm publish --workspace=packages/$pkg --access public $DRYRUN; then
-              echo "::warning::Failed to publish @doo-iconik/$pkg (may already exist)"
+            if [ "$pkg" = "core" ]; then
+              PKG_NAME="@ajentik/doo-iconik"
+            else
+              PKG_NAME="@ajentik/doo-iconik-$pkg"
+            fi
+            echo "Publishing $PKG_NAME..."
+            if ! npm publish --workspace=packages/$pkg $FLAGS; then
+              echo "::warning::Failed to publish $PKG_NAME (may already exist)"
               FAILED="$FAILED $pkg"
             fi
           done

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ npm run build
 
 ## Framework Packages
 
-All JS/TS framework packages depend on `@doo-iconik/core`. The component in each package:
+All JS/TS framework packages depend on `@ajentik/doo-iconik`. The component in each package:
 - Imports icon data and utilities from core
 - Renders SVGs using the framework's native patterns
 - Supports all shared props (name, size, spin, variant, animation, etc.)

--- a/README.md
+++ b/README.md
@@ -11,18 +11,18 @@
 
 | Package | Framework | Install |
 |---------|-----------|---------|
-| `@doo-iconik/core` | None (shared data) | `npm i @doo-iconik/core` |
-| `@doo-iconik/react` | React 18/19 | `npm i @doo-iconik/react` |
-| `@doo-iconik/vue` | Vue 3 | `npm i @doo-iconik/vue` |
-| `@doo-iconik/svelte` | Svelte 5 | `npm i @doo-iconik/svelte` |
-| `@doo-iconik/solid` | SolidJS | `npm i @doo-iconik/solid` |
-| `@doo-iconik/angular` | Angular 16+ | `npm i @doo-iconik/angular` |
-| `@doo-iconik/preact` | Preact 10 | `npm i @doo-iconik/preact` |
-| `@doo-iconik/qwik` | Qwik | `npm i @doo-iconik/qwik` |
-| `@doo-iconik/astro` | Astro 3/4 | `npm i @doo-iconik/astro` |
-| `@doo-iconik/lit` | Lit 3 | `npm i @doo-iconik/lit` |
-| `@doo-iconik/vanilla` | Vanilla JS / Web Components | `npm i @doo-iconik/vanilla` |
-| `@doo-iconik/alpine` | Alpine.js 3 | `npm i @doo-iconik/alpine` |
+| `@ajentik/doo-iconik` | None (shared data) | `npm i @ajentik/doo-iconik` |
+| `@ajentik/doo-iconik-react` | React 18/19 | `npm i @ajentik/doo-iconik-react` |
+| `@ajentik/doo-iconik-vue` | Vue 3 | `npm i @ajentik/doo-iconik-vue` |
+| `@ajentik/doo-iconik-svelte` | Svelte 5 | `npm i @ajentik/doo-iconik-svelte` |
+| `@ajentik/doo-iconik-solid` | SolidJS | `npm i @ajentik/doo-iconik-solid` |
+| `@ajentik/doo-iconik-angular` | Angular 16+ | `npm i @ajentik/doo-iconik-angular` |
+| `@ajentik/doo-iconik-preact` | Preact 10 | `npm i @ajentik/doo-iconik-preact` |
+| `@ajentik/doo-iconik-qwik` | Qwik | `npm i @ajentik/doo-iconik-qwik` |
+| `@ajentik/doo-iconik-astro` | Astro 3/4 | `npm i @ajentik/doo-iconik-astro` |
+| `@ajentik/doo-iconik-lit` | Lit 3 | `npm i @ajentik/doo-iconik-lit` |
+| `@ajentik/doo-iconik-vanilla` | Vanilla JS / Web Components | `npm i @ajentik/doo-iconik-vanilla` |
+| `@ajentik/doo-iconik-alpine` | Alpine.js 3 | `npm i @ajentik/doo-iconik-alpine` |
 | `doo_iconik` | Ruby on Rails | `gem 'doo_iconik'` |
 | `ajentik/doo-iconik-laravel` | Laravel 10/11/12 | `composer require ajentik/doo-iconik-laravel` |
 | `doo_iconik` | Flutter 3.10+ | `flutter pub add doo_iconik` |
@@ -32,7 +32,7 @@
 ### React
 
 ```jsx
-import { DooIconik } from '@doo-iconik/react';
+import { DooIconik } from '@ajentik/doo-iconik-react';
 
 function App() {
   return <DooIconik name="heart" size="lg" spin />;
@@ -43,7 +43,7 @@ function App() {
 
 ```vue
 <script setup>
-import { DooIconik } from '@doo-iconik/vue';
+import { DooIconik } from '@ajentik/doo-iconik-vue';
 </script>
 
 <template>
@@ -55,7 +55,7 @@ import { DooIconik } from '@doo-iconik/vue';
 
 ```svelte
 <script>
-  import { DooIconik } from '@doo-iconik/svelte';
+  import { DooIconik } from '@ajentik/doo-iconik-svelte';
 </script>
 
 <DooIconik name="heart" size="lg" spin />
@@ -64,7 +64,7 @@ import { DooIconik } from '@doo-iconik/vue';
 ### SolidJS
 
 ```jsx
-import { DooIconik } from '@doo-iconik/solid';
+import { DooIconik } from '@ajentik/doo-iconik-solid';
 
 function App() {
   return <DooIconik name="heart" size="lg" spin />;
@@ -74,7 +74,7 @@ function App() {
 ### Angular
 
 ```typescript
-import { DooIconikComponent } from '@doo-iconik/angular';
+import { DooIconikComponent } from '@ajentik/doo-iconik-angular';
 
 @Component({
   standalone: true,
@@ -87,7 +87,7 @@ export class AppComponent {}
 ### Preact
 
 ```jsx
-import { DooIconik } from '@doo-iconik/preact';
+import { DooIconik } from '@ajentik/doo-iconik-preact';
 
 function App() {
   return <DooIconik name="heart" size="lg" spin />;
@@ -97,7 +97,7 @@ function App() {
 ### Qwik
 
 ```jsx
-import { DooIconik } from '@doo-iconik/qwik';
+import { DooIconik } from '@ajentik/doo-iconik-qwik';
 
 export default component$(() => {
   return <DooIconik name="heart" size="lg" spin />;
@@ -108,7 +108,7 @@ export default component$(() => {
 
 ```astro
 ---
-import { DooIconik } from '@doo-iconik/astro';
+import { DooIconik } from '@ajentik/doo-iconik-astro';
 ---
 
 <DooIconik name="heart" size="lg" spin />
@@ -117,7 +117,7 @@ import { DooIconik } from '@doo-iconik/astro';
 ### Lit
 
 ```js
-import '@doo-iconik/lit';
+import '@ajentik/doo-iconik-lit';
 ```
 
 ```html
@@ -128,7 +128,7 @@ import '@doo-iconik/lit';
 
 ```js
 // Web Component
-import { register } from '@doo-iconik/vanilla';
+import { register } from '@ajentik/doo-iconik-vanilla';
 register();
 ```
 
@@ -138,7 +138,7 @@ register();
 
 ```js
 // Or programmatic usage
-import { createIcon } from '@doo-iconik/vanilla';
+import { createIcon } from '@ajentik/doo-iconik-vanilla';
 const svg = createIcon('heart', { size: 'lg', spin: true });
 document.body.appendChild(svg);
 ```
@@ -147,7 +147,7 @@ document.body.appendChild(svg);
 
 ```js
 import Alpine from 'alpinejs';
-import dooIconikPlugin from '@doo-iconik/alpine';
+import dooIconikPlugin from '@ajentik/doo-iconik-alpine';
 
 Alpine.plugin(dooIconikPlugin);
 Alpine.start();
@@ -308,10 +308,10 @@ Import individual icons for smaller bundles:
 
 ```typescript
 // Only bundles the heart icon (~200 bytes)
-import { heart } from '@doo-iconik/core/icons/heart';
+import { heart } from '@ajentik/doo-iconik/icons/heart';
 
 // All icons (~212KB)
-import { iconData } from '@doo-iconik/core';
+import { iconData } from '@ajentik/doo-iconik';
 ```
 
 ## Development

--- a/docs/index.html
+++ b/docs/index.html
@@ -1024,73 +1024,73 @@
     </div>
 
     <div class="usage-code active" data-tab="react" id="usage-panel-react" role="tabpanel" aria-labelledby="usageTabs">
-      <div class="install">npm install @doo-iconik/react</div>
-      <pre>import { DooIconik } from '@doo-iconik/react';
+      <div class="install">npm install @ajentik/doo-iconik-react</div>
+      <pre>import { DooIconik } from '@ajentik/doo-iconik-react';
 
 &lt;DooIconik name="heart" size="md" /&gt;
 &lt;DooIconik name="star" variant="neon" animation="pulse" /&gt;</pre>
     </div>
 
     <div class="usage-code" data-tab="vue" id="usage-panel-vue" role="tabpanel">
-      <div class="install">npm install @doo-iconik/vue</div>
-      <pre>import { DooIconik } from '@doo-iconik/vue';
+      <div class="install">npm install @ajentik/doo-iconik-vue</div>
+      <pre>import { DooIconik } from '@ajentik/doo-iconik-vue';
 
 &lt;DooIconik name="heart" size="md" /&gt;
 &lt;DooIconik name="star" variant="neon" animation="pulse" /&gt;</pre>
     </div>
 
     <div class="usage-code" data-tab="svelte" id="usage-panel-svelte" role="tabpanel">
-      <div class="install">npm install @doo-iconik/svelte</div>
-      <pre>import { DooIconik } from '@doo-iconik/svelte';
+      <div class="install">npm install @ajentik/doo-iconik-svelte</div>
+      <pre>import { DooIconik } from '@ajentik/doo-iconik-svelte';
 
 &lt;DooIconik name="heart" size="md" /&gt;
 &lt;DooIconik name="star" variant="neon" animation="pulse" /&gt;</pre>
     </div>
 
     <div class="usage-code" data-tab="angular" id="usage-panel-angular" role="tabpanel">
-      <div class="install">npm install @doo-iconik/angular</div>
-      <pre>import { DooIconikModule } from '@doo-iconik/angular';
+      <div class="install">npm install @ajentik/doo-iconik-angular</div>
+      <pre>import { DooIconikModule } from '@ajentik/doo-iconik-angular';
 
 &lt;doo-iconik name="heart" size="md"&gt;&lt;/doo-iconik&gt;
 &lt;doo-iconik name="star" variant="neon" animation="pulse"&gt;&lt;/doo-iconik&gt;</pre>
     </div>
 
     <div class="usage-code" data-tab="solid" id="usage-panel-solid" role="tabpanel">
-      <div class="install">npm install @doo-iconik/solid</div>
-      <pre>import { DooIconik } from '@doo-iconik/solid';
+      <div class="install">npm install @ajentik/doo-iconik-solid</div>
+      <pre>import { DooIconik } from '@ajentik/doo-iconik-solid';
 
 &lt;DooIconik name="heart" size="md" /&gt;
 &lt;DooIconik name="star" variant="neon" animation="pulse" /&gt;</pre>
     </div>
 
     <div class="usage-code" data-tab="lit" id="usage-panel-lit" role="tabpanel">
-      <div class="install">npm install @doo-iconik/lit</div>
-      <pre>import '@doo-iconik/lit';
+      <div class="install">npm install @ajentik/doo-iconik-lit</div>
+      <pre>import '@ajentik/doo-iconik-lit';
 
 &lt;doo-iconik name="heart" size="md"&gt;&lt;/doo-iconik&gt;
 &lt;doo-iconik name="star" variant="neon" animation="pulse"&gt;&lt;/doo-iconik&gt;</pre>
     </div>
 
     <div class="usage-code" data-tab="preact" id="usage-panel-preact" role="tabpanel">
-      <div class="install">npm install @doo-iconik/preact</div>
-      <pre>import { DooIconik } from '@doo-iconik/preact';
+      <div class="install">npm install @ajentik/doo-iconik-preact</div>
+      <pre>import { DooIconik } from '@ajentik/doo-iconik-preact';
 
 &lt;DooIconik name="heart" size="md" /&gt;
 &lt;DooIconik name="star" variant="neon" animation="pulse" /&gt;</pre>
     </div>
 
     <div class="usage-code" data-tab="qwik" id="usage-panel-qwik" role="tabpanel">
-      <div class="install">npm install @doo-iconik/qwik</div>
-      <pre>import { DooIconik } from '@doo-iconik/qwik';
+      <div class="install">npm install @ajentik/doo-iconik-qwik</div>
+      <pre>import { DooIconik } from '@ajentik/doo-iconik-qwik';
 
 &lt;DooIconik name="heart" size="md" /&gt;
 &lt;DooIconik name="star" variant="neon" animation="pulse" /&gt;</pre>
     </div>
 
     <div class="usage-code" data-tab="astro" id="usage-panel-astro" role="tabpanel">
-      <div class="install">npm install @doo-iconik/astro</div>
+      <div class="install">npm install @ajentik/doo-iconik-astro</div>
       <pre>---
-import { DooIconik } from '@doo-iconik/astro';
+import { DooIconik } from '@ajentik/doo-iconik-astro';
 ---
 
 &lt;DooIconik name="heart" size="md" /&gt;
@@ -1098,16 +1098,16 @@ import { DooIconik } from '@doo-iconik/astro';
     </div>
 
     <div class="usage-code" data-tab="vanilla" id="usage-panel-vanilla" role="tabpanel">
-      <div class="install">npm install @doo-iconik/vanilla</div>
-      <pre>import { createIcon } from '@doo-iconik/vanilla';
+      <div class="install">npm install @ajentik/doo-iconik-vanilla</div>
+      <pre>import { createIcon } from '@ajentik/doo-iconik-vanilla';
 
 const icon = createIcon({ name: 'heart', size: 'md' });
 document.body.appendChild(icon);</pre>
     </div>
 
     <div class="usage-code" data-tab="alpine" id="usage-panel-alpine" role="tabpanel">
-      <div class="install">npm install @doo-iconik/alpine</div>
-      <pre>import { dooIconikPlugin } from '@doo-iconik/alpine';
+      <div class="install">npm install @ajentik/doo-iconik-alpine</div>
+      <pre>import { dooIconikPlugin } from '@ajentik/doo-iconik-alpine';
 Alpine.plugin(dooIconikPlugin);
 
 &lt;div x-data x-doo-iconik="{ name: 'heart', size: 'md' }"&gt;&lt;/div&gt;</pre>
@@ -1582,15 +1582,36 @@ DooIconik(name: 'star', variant: DooIconikVariant.neon)</pre>
         t.setAttribute('aria-selected', isReact ? 'true' : 'false');
       });
       previewState.framework = 'react';
+      previewState.triggerEl = document.activeElement;
       document.getElementById('previewName').textContent = iconName;
       document.getElementById('previewOverlay').classList.add('active');
       document.getElementById('previewPanel').classList.add('active');
+      document.addEventListener('keydown', trapPreviewFocus);
       updatePreview();
+      document.getElementById('previewClose').focus();
     }
 
     function closePreview() {
+      document.removeEventListener('keydown', trapPreviewFocus);
       document.getElementById('previewOverlay').classList.remove('active');
       document.getElementById('previewPanel').classList.remove('active');
+      if (previewState.triggerEl) previewState.triggerEl.focus();
+    }
+
+    function trapPreviewFocus(e) {
+      if (e.key !== 'Tab') return;
+      var panel = document.getElementById('previewPanel');
+      var focusable = panel.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
+      if (!focusable.length) return;
+      var first = focusable[0];
+      var last = focusable[focusable.length - 1];
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
     }
 
     function updatePreview() {
@@ -1656,18 +1677,18 @@ DooIconik(name: 'star', variant: DooIconikVariant.neon)</pre>
       const attrs = props.map(([k,v]) => v === true ? ` ${k}` : ` ${k}="${v}"`).join('');
 
       if (fw === 'react' || fw === 'vue' || fw === 'svelte' || fw === 'solid' || fw === 'preact') {
-        const pkg = `@doo-iconik/${fw}`;
+        const pkg = `@ajentik/doo-iconik-${fw}`;
         code = `import { DooIconik } from '${pkg}';\n\n<DooIconik name="${name}"${attrs} />`;
       } else if (fw === 'angular' || fw === 'lit') {
-        const pkg = `@doo-iconik/${fw}`;
+        const pkg = `@ajentik/doo-iconik-${fw}`;
         const importLine = fw === 'angular'
           ? `import { DooIconikModule } from '${pkg}';`
           : `import '${pkg}';`;
         code = `${importLine}\n\n<doo-iconik name="${name}"${attrs}></doo-iconik>`;
       } else if (fw === 'qwik') {
-        code = `import { DooIconik } from '@doo-iconik/qwik';\n\n<DooIconik name="${name}"${attrs} />`;
+        code = `import { DooIconik } from '@ajentik/doo-iconik-qwik';\n\n<DooIconik name="${name}"${attrs} />`;
       } else if (fw === 'astro') {
-        code = `---\nimport { DooIconik } from '@doo-iconik/astro';\n---\n\n<DooIconik name="${name}"${attrs} />`;
+        code = `---\nimport { DooIconik } from '@ajentik/doo-iconik-astro';\n---\n\n<DooIconik name="${name}"${attrs} />`;
       } else if (fw === 'vanilla') {
         const objProps = [['name', `'${name}'`]];
         if (s.size !== 'md') objProps.push(['size', `'${s.size}'`]);
@@ -1676,14 +1697,14 @@ DooIconik(name: 'star', variant: DooIconikVariant.neon)</pre>
         if (s.flipH) objProps.push(['flipHorizontal', 'true']);
         if (s.flipV) objProps.push(['flipVertical', 'true']);
         const objStr = objProps.map(([k,v]) => `${k}: ${v}`).join(', ');
-        code = `import { createIcon } from '@doo-iconik/vanilla';\n\nconst icon = createIcon({ ${objStr} });\ndocument.body.appendChild(icon);`;
+        code = `import { createIcon } from '@ajentik/doo-iconik-vanilla';\n\nconst icon = createIcon({ ${objStr} });\ndocument.body.appendChild(icon);`;
       } else if (fw === 'alpine') {
         const objProps = [['name', `'${name}'`]];
         if (s.size !== 'md') objProps.push(['size', `'${s.size}'`]);
         if (s.variant !== 'default') objProps.push(['variant', `'${s.variant}'`]);
         if (s.animation !== 'none') objProps.push(['animation', `'${s.animation}'`]);
         const objStr = objProps.map(([k,v]) => `${k}: ${v}`).join(', ');
-        code = `import { dooIconikPlugin } from '@doo-iconik/alpine';\nAlpine.plugin(dooIconikPlugin);\n\n<div x-data x-doo-iconik="{ ${objStr} }"></div>`;
+        code = `import { dooIconikPlugin } from '@ajentik/doo-iconik-alpine';\nAlpine.plugin(dooIconikPlugin);\n\n<div x-data x-doo-iconik="{ ${objStr} }"></div>`;
       } else if (fw === 'laravel') {
         code = `<x-doo-iconik name="${name}"${attrs} />`;
       } else if (fw === 'rails') {

--- a/docs/specs/041-bump-dev-deps.md
+++ b/docs/specs/041-bump-dev-deps.md
@@ -1,0 +1,29 @@
+# Spec #41 — Bump devDependency Minimums
+
+**Issue**: https://github.com/ajentik/doo-iconik/issues/41
+**Status**: ✅ DONE — merged in PR #46
+
+## Summary
+
+Bump outdated devDependency minimum versions in `packages/svelte/package.json` and root `package.json` to document actual tested compatibility.
+
+## Changes Made (PR #46)
+
+| File | Dependency | Before | After |
+|------|-----------|--------|-------|
+| `packages/svelte/package.json` | `svelte` (dev) | `^5.0.0` | `^5.50.0` |
+| `packages/svelte/package.json` | `@sveltejs/package` (dev) | `^2.0.0` | `^2.5.0` |
+| `packages/svelte/package.json` | `typescript` (dev) | `^5.0.0` | `^5.8.0` |
+| `package.json` | `typescript` (dev) | `^5.0.0` | `^5.8.0` |
+
+`peerDependencies` were correctly left untouched (`svelte: "^5.0.0"`).
+
+## Verification
+
+- [x] `npm install` succeeds
+- [x] `npx vitest run` — 47/47 tests pass
+- [x] CI passes
+
+## Resolution
+
+Close issue #41 — fully implemented.

--- a/docs/specs/042-docs-gallery-improvements.md
+++ b/docs/specs/042-docs-gallery-improvements.md
@@ -1,0 +1,95 @@
+# Spec #42 — Docs Gallery Improvements
+
+**Issue**: https://github.com/ajentik/doo-iconik/issues/42
+**Status**: 🟡 ~95% done — one remaining item
+
+## Summary
+
+Improve the interactive icon gallery at `docs/index.html` with light/dark mode, icon count, URL state, accessibility, and performance.
+
+## What Was Implemented (PR #46)
+
+| Feature | Status | Details |
+|---------|--------|---------|
+| Light/dark toggle | ✅ | Button in header, `localStorage` persistence, `prefers-color-scheme` detection |
+| Icon count badge | ✅ | "Showing **X** of **595**" in controls bar |
+| URL state sync | ✅ | `?q=` and `?cat=` params via `history.replaceState` |
+| Empty state | ✅ | Friendly message with search icon when no results |
+| OG meta tags | ✅ | `og:title`, `og:description`, `og:type`, `og:url`, `og:image`, `theme-color` |
+| Lazy rendering | ✅ | `IntersectionObserver` for icon SVG rendering |
+| Skip-to-content link | ✅ | `<a href="#icon-grid" class="skip-link">Skip to icons</a>` at line 882 |
+| Preview panel a11y | ✅ | `role="dialog"` + `aria-modal="true"` + `aria-label` |
+
+## Remaining Work
+
+### 1. Preview Panel Focus Trap
+
+**Current behavior**: When the preview panel opens, focus is not moved into the panel and the user can Tab behind the overlay to the grid and controls.
+
+**Required changes** in `docs/index.html`:
+
+#### a. Move focus on open
+In the `openPreview()` function (~line 1585), after `.classList.add('active')`:
+```js
+// Focus the close button when preview opens
+document.getElementById('previewClose').focus();
+```
+
+#### b. Trap focus inside panel
+Add a keydown listener when panel is open that wraps Tab between the first and last focusable elements inside `#previewPanel`:
+```js
+function trapFocus(e) {
+  if (e.key !== 'Tab') return;
+  const panel = document.getElementById('previewPanel');
+  const focusable = panel.querySelectorAll(
+    'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+  );
+  const first = focusable[0];
+  const last = focusable[focusable.length - 1];
+  if (e.shiftKey && document.activeElement === first) {
+    e.preventDefault();
+    last.focus();
+  } else if (!e.shiftKey && document.activeElement === last) {
+    e.preventDefault();
+    first.focus();
+  }
+}
+```
+
+#### c. Restore focus on close
+In `closePreview()`, restore focus to the card that triggered the preview:
+```js
+// Store trigger element in openPreview:
+previewState.triggerEl = document.activeElement;
+
+// In closePreview:
+if (previewState.triggerEl) previewState.triggerEl.focus();
+```
+
+#### d. Add/remove trap listener
+```js
+// In openPreview:
+document.addEventListener('keydown', trapFocus);
+
+// In closePreview:
+document.removeEventListener('keydown', trapFocus);
+```
+
+### Files to Change
+
+- `docs/index.html` — add focus management to `openPreview()` and `closePreview()` functions
+
+### Acceptance Criteria
+
+- [ ] Opening preview moves focus to close button
+- [ ] Tab/Shift+Tab cycles within the preview panel only
+- [ ] Closing preview returns focus to the triggering icon card
+- [ ] Escape still closes the panel (already works)
+
+### Estimated Effort
+
+~20 minutes
+
+## Out of Scope
+
+All other items from the original issue are complete. No further changes needed.

--- a/docs/specs/043-publish-packages.md
+++ b/docs/specs/043-publish-packages.md
@@ -1,0 +1,149 @@
+# Spec #43 — Publish All Packages to Registries
+
+**Issue**: https://github.com/ajentik/doo-iconik/issues/43
+**Status**: 🔴 NOT STARTED — all 15 packages unpublished
+
+## Summary
+
+Publish all 15 framework packages to their respective registries (npm, Packagist, RubyGems, pub.dev) so users can install them as documented in the README.
+
+## Current State
+
+All 12 npm packages return 404. The `@ajentik` npm org does not exist. No packages are on any registry.
+
+## Pre-Publish Fixes Required
+
+### 1. Create npm Org
+
+Create the `@ajentik` npm organization at https://www.npmjs.com/org/create.
+
+### 2. Copy LICENSE Into Each Package Directory
+
+npm only includes files listed in the `files` array (plus `package.json`). LICENSE must be present in each package directory.
+
+**Script** (run from repo root):
+```bash
+for dir in packages/*/; do
+  cp LICENSE "$dir"
+done
+```
+
+**Files created** (13 copies):
+- `packages/{core,react,vue,svelte,angular,solid,lit,preact,qwik,alpine,vanilla,astro,flutter}/LICENSE`
+- `packages/laravel/LICENSE` (already has MIT in composer.json but file copy is good practice)
+- `packages/rails/LICENSE`
+
+### 3. Add LICENSE + README.md to `files` Array
+
+Update every npm package's `package.json`:
+
+| Package | Current `files` | New `files` |
+|---------|----------------|-------------|
+| core | `["dist"]` | `["dist", "LICENSE", "README.md"]` |
+| react | `["dist"]` | `["dist", "LICENSE", "README.md"]` |
+| vue | `["src"]` | `["src", "LICENSE", "README.md"]` |
+| svelte | `["dist"]` | `["dist", "LICENSE", "README.md"]` |
+| angular | `["dist"]` | `["dist", "LICENSE", "README.md"]` |
+| solid | `["dist"]` | `["dist", "LICENSE", "README.md"]` |
+| lit | `["dist"]` | `["dist", "LICENSE", "README.md"]` |
+| preact | `["dist"]` | `["dist", "LICENSE", "README.md"]` |
+| qwik | `["dist"]` | `["dist", "LICENSE", "README.md"]` |
+| alpine | `["dist"]` | `["dist", "LICENSE", "README.md"]` |
+| vanilla | `["dist"]` | `["dist", "LICENSE", "README.md"]` |
+| astro | `["src"]` | `["src", "LICENSE", "README.md"]` |
+
+### 4. Fix `file:../core` Dependency for Publishing
+
+All 11 framework packages use `"@ajentik/doo-iconik": "file:../core"` which is invalid in published packages. Two approaches:
+
+**Option A (recommended)**: Auto-rewrite at publish time in the CI workflow (see spec #44). No code changes needed — the workflow rewrites before `npm publish` and never commits the change.
+
+**Option B**: Change to `"@ajentik/doo-iconik": "^1.0.0"` in source. This breaks local `npm install` unless core is published first or workspaces resolves it. Not recommended.
+
+→ **Go with Option A** (handled by #44 workflow improvements).
+
+### 5. Verify Package Metadata
+
+All packages already have correct:
+- [x] `name` — `@ajentik/doo-iconik` scoped
+- [x] `version` — `1.0.0`
+- [x] `license` — `MIT`
+- [x] `main` / `module` / `types` / `exports`
+- [x] `repository` with `directory`
+- [x] `keywords`
+- [x] `homepage` and `bugs`
+- [x] `sideEffects: false` (or correct value for lit)
+
+## Publish Sequence
+
+### npm (12 packages)
+
+Triggered by creating a GitHub release. The workflow (`.github/workflows/publish.yml`) handles:
+1. Generate icon data
+2. Build core first, then all packages
+3. Run tests
+4. Publish `core` first, then all framework packages
+
+**Prerequisite secrets**:
+- `NPM_TOKEN` — npm automation token with publish access to `@ajentik` scope
+
+### Packagist — `ajentik/doo-iconik-laravel`
+
+1. Go to https://packagist.org/packages/submit
+2. Submit `https://github.com/ajentik/doo-iconik` with path `packages/laravel`
+3. Or: create a separate `ajentik/doo-iconik-laravel` repo as a subtree/mirror
+4. Add GitHub webhook for auto-update on push
+
+**Note**: Packagist requires the `composer.json` to be at the repo root of the submitted URL. For a monorepo, the recommended approach is a read-only subtree split repo.
+
+### RubyGems — `doo_iconik`
+
+```bash
+cd packages/rails
+gem build doo_iconik.gemspec
+gem push doo_iconik-1.0.0.gem
+```
+
+**Prerequisite**: RubyGems.org API key set up locally or as `GEM_HOST_API_KEY` secret.
+
+### pub.dev — `doo_iconik`
+
+```bash
+cd packages/flutter
+dart pub publish
+```
+
+**Prerequisites**:
+- Google account verification
+- `pubspec.yaml` already has `homepage` ✅
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `packages/*/LICENSE` | New files (copy from root) |
+| 12 × `packages/*/package.json` | Add `LICENSE`, `README.md` to `files` array |
+| `.github/workflows/publish.yml` | Handled by #44 |
+
+## Acceptance Criteria
+
+- [ ] `@ajentik` npm org exists
+- [ ] `NPM_TOKEN` secret added to repo
+- [ ] LICENSE file present in each package directory
+- [ ] Each npm package's `files` includes `LICENSE` and `README.md`
+- [ ] `npm pack --workspace=packages/core --dry-run` shows LICENSE + README in tarball
+- [ ] All 12 npm packages published and installable
+- [ ] `npm install @ajentik/doo-iconik-react` resolves `@ajentik/doo-iconik` from npm
+- [ ] Laravel package documented for Packagist (or published)
+- [ ] Rails gem documented for RubyGems (or published)
+- [ ] Flutter package documented for pub.dev (or published)
+
+## Dependencies
+
+- **Blocked by #44**: The publish workflow needs the `file:../core` rewrite step before packages can be published successfully.
+
+## Estimated Effort
+
+- npm setup + publish: ~1 hour
+- LICENSE/files changes: ~30 minutes
+- Non-npm registries: ~1 hour each (or document manual process)

--- a/docs/specs/044-harden-publish-workflow.md
+++ b/docs/specs/044-harden-publish-workflow.md
@@ -1,0 +1,246 @@
+# Spec #44 — Harden Publish Workflow
+
+**Issue**: https://github.com/ajentik/doo-iconik/issues/44
+**Status**: 🟡 ~30% done — test gate and core-first build added, 4 items remaining
+
+## Summary
+
+Improve `.github/workflows/publish.yml` with provenance, version sync, automatic `file:` dependency rewrite, and icon count verification.
+
+## Current Workflow (after PR #46)
+
+```yaml
+steps:
+  - checkout
+  - setup-node (v24, registry-url: npm)
+  - npm install
+  - Generate icon data (node generate.mjs)
+  - Build core package first              # ✅ Added in PR #46
+  - Build all packages (--workspaces)
+  - Run tests (npx vitest run)            # ✅ Added in PR #46
+  - Publish loop: core → 11 framework packages (--access public)
+```
+
+## What's Done
+
+- [x] Build core before other packages
+- [x] Test gate (`npx vitest run`) before publish
+
+## Remaining Changes
+
+### 1. Add `--provenance` Flag
+
+npm provenance links published packages to their source commit and build, improving supply-chain security. The workflow already has `id-token: write` permission.
+
+**Change**: In the publish step, add `--provenance` to the `npm publish` command.
+
+```diff
+- if ! npm publish --workspace=packages/$pkg --access public $DRYRUN; then
++ if ! npm publish --workspace=packages/$pkg --access public --provenance $DRYRUN; then
+```
+
+**Location**: `.github/workflows/publish.yml` line 55
+
+### 2. Add Version Sync Check
+
+Verify all `package.json` versions match the release tag before publishing. This prevents publishing mismatched versions.
+
+**Add step** after "Run tests", before "Publish":
+
+```yaml
+      - name: Verify version sync
+        if: github.event_name == 'release'
+        run: |
+          TAG="${GITHUB_REF#refs/tags/v}"
+          echo "Release tag version: $TAG"
+          FAIL=0
+          for pkg in packages/*/package.json; do
+            VER=$(node -e "console.log(JSON.parse(require('fs').readFileSync('$pkg','utf8')).version)")
+            if [ "$VER" != "$TAG" ]; then
+              echo "::error::$pkg version ($VER) does not match tag v$TAG"
+              FAIL=1
+            fi
+          done
+          if [ "$FAIL" -eq 1 ]; then exit 1; fi
+```
+
+**Note**: This checks all 12 npm packages + laravel/rails/flutter. If non-npm packages version independently, exclude them:
+```bash
+for pkg in packages/{core,react,vue,svelte,angular,solid,lit,preact,qwik,alpine,vanilla,astro}/package.json; do
+```
+
+### 3. Auto-Rewrite `file:../core` → `^<version>`
+
+All 11 framework packages use `"@ajentik/doo-iconik": "file:../core"` for local development. This must be rewritten to a semver range before publishing.
+
+**Add step** after "Verify version sync", before "Publish":
+
+```yaml
+      - name: Rewrite core dependency for publish
+        run: |
+          CORE_VER=$(node -e "console.log(JSON.parse(require('fs').readFileSync('packages/core/package.json','utf8')).version)")
+          echo "Core version: $CORE_VER"
+          for pkg in react vue svelte angular solid lit preact qwik alpine vanilla astro; do
+            FILE="packages/$pkg/package.json"
+            node -e "
+              const fs = require('fs');
+              const p = JSON.parse(fs.readFileSync('$FILE', 'utf8'));
+              if (p.dependencies && p.dependencies['@ajentik/doo-iconik'] && p.dependencies['@ajentik/doo-iconik'].startsWith('file:')) {
+                p.dependencies['@ajentik/doo-iconik'] = '^$CORE_VER';
+                fs.writeFileSync('$FILE', JSON.stringify(p, null, 2) + '\n');
+                console.log('Rewrote $FILE: @ajentik/doo-iconik → ^$CORE_VER');
+              }
+            "
+          done
+```
+
+**Important**: This rewrites files only in the CI runner, never committed to the repo. Local development continues using `file:../core`.
+
+### 4. Add Icon Count Verification
+
+Mirror the CI workflow's icon count check to ensure data integrity before publishing.
+
+**Add step** after "Build all packages":
+
+```yaml
+      - name: Verify icon counts
+        run: |
+          RAW_COUNT=$(node -e "const d=JSON.parse(require('fs').readFileSync('icon-data-raw.json','utf8')); console.log(Object.keys(d).length)")
+          CORE_COUNT=$(grep -c 'viewBox: "' packages/core/src/icon-data.ts)
+          echo "Raw: $RAW_COUNT, Core: $CORE_COUNT"
+          if [ "$CORE_COUNT" != "$RAW_COUNT" ]; then
+            echo "::error::Core icon count ($CORE_COUNT) does not match raw ($RAW_COUNT)"
+            exit 1
+          fi
+```
+
+## Complete Updated Workflow
+
+```yaml
+name: Publish to npm
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: 'Dry run (no actual publish)'
+        required: false
+        default: 'false'
+        type: boolean
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          registry-url: 'https://registry.npmjs.org'
+
+      - run: npm install
+
+      - name: Generate icon data
+        run: node generate.mjs
+
+      - name: Build core package first
+        run: npm run build --workspace=packages/core
+
+      - name: Build all packages
+        run: npm run build --workspaces
+
+      - name: Verify icon counts
+        run: |
+          RAW_COUNT=$(node -e "const d=JSON.parse(require('fs').readFileSync('icon-data-raw.json','utf8')); console.log(Object.keys(d).length)")
+          CORE_COUNT=$(grep -c 'viewBox: "' packages/core/src/icon-data.ts)
+          echo "Raw: $RAW_COUNT, Core: $CORE_COUNT"
+          if [ "$CORE_COUNT" != "$RAW_COUNT" ]; then
+            echo "::error::Icon count mismatch: core=$CORE_COUNT raw=$RAW_COUNT"
+            exit 1
+          fi
+
+      - name: Run tests
+        run: npx vitest run
+
+      - name: Verify version sync
+        if: github.event_name == 'release'
+        run: |
+          TAG="${GITHUB_REF#refs/tags/v}"
+          echo "Release tag version: $TAG"
+          FAIL=0
+          for pkg in packages/{core,react,vue,svelte,angular,solid,lit,preact,qwik,alpine,vanilla,astro}/package.json; do
+            VER=$(node -e "console.log(JSON.parse(require('fs').readFileSync('$pkg','utf8')).version)")
+            if [ "$VER" != "$TAG" ]; then
+              echo "::error::$pkg version ($VER) != tag v$TAG"
+              FAIL=1
+            fi
+          done
+          if [ "$FAIL" -eq 1 ]; then exit 1; fi
+
+      - name: Rewrite core dependency for publish
+        run: |
+          CORE_VER=$(node -e "console.log(JSON.parse(require('fs').readFileSync('packages/core/package.json','utf8')).version)")
+          for pkg in react vue svelte angular solid lit preact qwik alpine vanilla astro; do
+            FILE="packages/$pkg/package.json"
+            node -e "
+              const fs = require('fs');
+              const p = JSON.parse(fs.readFileSync('$FILE', 'utf8'));
+              if (p.dependencies?.['@ajentik/doo-iconik']?.startsWith('file:')) {
+                p.dependencies['@ajentik/doo-iconik'] = '^' + '$CORE_VER';
+                fs.writeFileSync('$FILE', JSON.stringify(p, null, 2) + '\n');
+                console.log('Rewrote: ' + '$FILE');
+              }
+            "
+          done
+
+      - name: Publish packages
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          DRY_RUN: ${{ inputs.dry-run }}
+        run: |
+          FLAGS="--access public --provenance"
+          if [ "$DRY_RUN" = "true" ]; then FLAGS="$FLAGS --dry-run"; fi
+
+          FAILED=""
+          for pkg in core react vue svelte angular solid lit preact qwik alpine vanilla astro; do
+            if [ "$pkg" = "core" ]; then PKG_NAME="@ajentik/doo-iconik"; else PKG_NAME="@ajentik/doo-iconik-$pkg"; fi
+            echo "Publishing $PKG_NAME..."
+            if ! npm publish --workspace=packages/$pkg $FLAGS; then
+              echo "::warning::Failed to publish $PKG_NAME (may already exist)"
+              FAILED="$FAILED $pkg"
+            fi
+          done
+
+          if [ -n "$FAILED" ]; then
+            echo "::notice::Packages that failed to publish:$FAILED"
+          fi
+```
+
+## Files Changed
+
+- `.github/workflows/publish.yml` — full replacement with hardened version above
+
+## Acceptance Criteria
+
+- [ ] `--provenance` flag on all npm publish calls
+- [ ] Version sync check runs on release trigger (skipped for workflow_dispatch)
+- [ ] `file:../core` rewritten to `^<core-version>` before publish
+- [ ] Icon count verified before publish
+- [ ] Tests still gate the publish
+- [ ] Core still published before framework packages
+- [ ] Dry-run mode still works via workflow_dispatch
+- [ ] Individual package failure does not block remaining packages
+
+## Dependencies
+
+- **Blocks #43**: This workflow must be updated before the first publish.
+
+## Estimated Effort
+
+~30 minutes (single file change, well-defined steps)

--- a/docs/superpowers/plans/2026-03-22-community-health.md
+++ b/docs/superpowers/plans/2026-03-22-community-health.md
@@ -67,7 +67,7 @@ npm run build
 
 ## Framework Packages
 
-All JS/TS framework packages depend on `@doo-iconik/core`. The component in each package:
+All JS/TS framework packages depend on `@ajentik/doo-iconik`. The component in each package:
 - Imports icon data and utilities from core
 - Renders SVGs using the framework's native patterns
 - Supports all shared props (name, size, spin, variant, animation, etc.)
@@ -174,7 +174,7 @@ labels: bug
 
 ## Package
 
-Which package? (e.g., `@doo-iconik/react`, `@doo-iconik/vue`, `doo_iconik` gem)
+Which package? (e.g., `@ajentik/doo-iconik-react`, `@ajentik/doo-iconik-vue`, `doo_iconik` gem)
 
 ## Version
 

--- a/docs/superpowers/plans/2026-03-22-docs-interactive-preview.md
+++ b/docs/superpowers/plans/2026-03-22-docs-interactive-preview.md
@@ -44,7 +44,7 @@ Modify the icon card click handler:
 
 Example generated snippet:
 ```jsx
-import { DooIconik } from '@doo-iconik/react';
+import { DooIconik } from '@ajentik/doo-iconik-react';
 
 <DooIconik name="heart" size="lg" variant="neon" animation="heartbeat" />
 ```
@@ -85,7 +85,7 @@ git commit -m "docs: add interactive preview panel with live code generation"
 │                                          │
 │  ┌─ React ─┬─ Vue ─┬─ Svelte ─┬─ ... ─┐ │
 │  │ import { DooIconik }         [Copy] │ │
-│  │   from '@doo-iconik/react';         │ │
+│  │   from '@ajentik/doo-iconik-react';         │ │
 │  │                                     │ │
 │  │ <DooIconik                          │ │
 │  │   name="heart"                      │ │

--- a/docs/superpowers/plans/2026-03-22-npm-publish-workflow.md
+++ b/docs/superpowers/plans/2026-03-22-npm-publish-workflow.md
@@ -63,7 +63,8 @@ jobs:
           fi
 
           for pkg in core react vue svelte angular solid lit preact qwik alpine vanilla astro; do
-            echo "Publishing @doo-iconik/$pkg..."
+            if [ "$pkg" = "core" ]; then PKG_NAME="@ajentik/doo-iconik"; else PKG_NAME="@ajentik/doo-iconik-$pkg"; fi
+            echo "Publishing $PKG_NAME..."
             npm publish --workspace=packages/$pkg --access public $DRYRUN || echo "Failed to publish $pkg (may already exist)"
           done
 ```

--- a/docs/superpowers/plans/2026-03-22-package-metadata.md
+++ b/docs/superpowers/plans/2026-03-22-package-metadata.md
@@ -10,7 +10,7 @@
 
 ---
 
-### Task 1: Add metadata to `@doo-iconik/core`
+### Task 1: Add metadata to `@ajentik/doo-iconik`
 
 **Files:**
 - Modify: `packages/core/package.json`

--- a/docs/superpowers/plans/2026-03-22-readme-badges.md
+++ b/docs/superpowers/plans/2026-03-22-readme-badges.md
@@ -65,12 +65,12 @@ git commit -m "docs: add CI, license, icon count, and framework badges to README
 
 - [ ] **Step 1: Add npm version badge to each package README**
 
-For each JS/TS package, add a badge line after the `# @doo-iconik/{name}` heading:
+For each JS/TS package, add a badge line after the `# @ajentik/doo-iconik[-{name}]` heading:
 
 ```markdown
-# @doo-iconik/{name}
+# @ajentik/doo-iconik[-{name}]
 
-[![npm version](https://img.shields.io/npm/v/@doo-iconik/{name}.svg)](https://www.npmjs.com/package/@doo-iconik/{name})
+[![npm version](https://img.shields.io/npm/v/@ajentik/doo-iconik[-{name}].svg)](https://www.npmjs.com/package/@ajentik/doo-iconik[-{name}])
 ```
 
 Replace `{name}` with each package name: core, react, vue, svelte, angular, solid, lit, preact, qwik, alpine, vanilla, astro.

--- a/docs/superpowers/plans/2026-03-22-tree-shaking.md
+++ b/docs/superpowers/plans/2026-03-22-tree-shaking.md
@@ -4,14 +4,14 @@
 
 **Goal:** Enable per-icon imports so bundlers can tree-shake unused icons, reducing the 212KB monolith to only the icons actually used.
 
-**Architecture:** Extend `generate.mjs` to produce individual icon modules at `packages/core/src/icons/{name}.ts`, each exporting a single `IconData` object. Add an export map in `packages/core/package.json` for `@doo-iconik/core/icons/{name}`. The existing monolith `icon-data.ts` remains for consumers who want all icons. Consumers can then do:
+**Architecture:** Extend `generate.mjs` to produce individual icon modules at `packages/core/src/icons/{name}.ts`, each exporting a single `IconData` object. Add an export map in `packages/core/package.json` for `@ajentik/doo-iconik/icons/{name}`. The existing monolith `icon-data.ts` remains for consumers who want all icons. Consumers can then do:
 
 ```typescript
 // All icons (existing — 212KB)
-import { iconData } from '@doo-iconik/core';
+import { iconData } from '@ajentik/doo-iconik';
 
 // Single icon (new — ~200 bytes)
-import { heart } from '@doo-iconik/core/icons/heart';
+import { heart } from '@ajentik/doo-iconik/icons/heart';
 ```
 
 **Tech Stack:** Node.js (generate.mjs), TypeScript, package.json exports map
@@ -164,10 +164,10 @@ Import individual icons for smaller bundles:
 
 \```typescript
 // Only bundles the heart icon (~200 bytes)
-import { heart } from '@doo-iconik/core/icons/heart';
+import { heart } from '@ajentik/doo-iconik/icons/heart';
 
 // All icons (~212KB)
-import { iconData } from '@doo-iconik/core';
+import { iconData } from '@ajentik/doo-iconik';
 \```
 ```
 

--- a/docs/superpowers/plans/2026-03-22-unit-tests.md
+++ b/docs/superpowers/plans/2026-03-22-unit-tests.md
@@ -2,7 +2,7 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Add unit test coverage for `@doo-iconik/core` utilities, icon data integrity, and the React component as a representative framework adapter.
+**Goal:** Add unit test coverage for `@ajentik/doo-iconik` utilities, icon data integrity, and the React component as a representative framework adapter.
 
 **Architecture:** Use Vitest as the test runner — it's fast, ESM-native, and works with TypeScript out of the box. Tests live alongside source in `packages/{pkg}/src/__tests__/`. Core tests cover all utility functions + icon data validation. React tests use `@testing-library/react` for component rendering. No tests for every framework adapter — React serves as the reference; other frameworks are structurally identical.
 

--- a/packages/alpine/LICENSE
+++ b/packages/alpine/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Ajentik
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/alpine/README.md
+++ b/packages/alpine/README.md
@@ -1,6 +1,6 @@
-# @doo-iconik/alpine
+# @ajentik/doo-iconik-alpine
 
-[![npm version](https://img.shields.io/npm/v/@doo-iconik/alpine.svg)](https://www.npmjs.com/package/@doo-iconik/alpine)
+[![npm version](https://img.shields.io/npm/v/@ajentik/doo-iconik-alpine.svg)](https://www.npmjs.com/package/@ajentik/doo-iconik-alpine)
 
 Alpine.js plugin: 595 hand-drawn doodle-style SVG icons for Alpine.js 3.
 
@@ -9,14 +9,14 @@ Part of [doo-iconik](https://github.com/ajentik/doo-iconik).
 ## Install
 
 ```bash
-npm i @doo-iconik/alpine
+npm i @ajentik/doo-iconik-alpine
 ```
 
 ## Usage
 
 ```js
 import Alpine from 'alpinejs';
-import { dooIconikPlugin } from '@doo-iconik/alpine';
+import { dooIconikPlugin } from '@ajentik/doo-iconik-alpine';
 
 Alpine.plugin(dooIconikPlugin);
 Alpine.start();

--- a/packages/alpine/package.json
+++ b/packages/alpine/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@doo-iconik/alpine",
+  "name": "@ajentik/doo-iconik-alpine",
   "version": "1.0.0",
   "description": "Alpine.js adapter (directive + magic) for doo-iconik icons",
   "license": "MIT",
@@ -20,12 +20,12 @@
       "require": "./dist/index.cjs"
     }
   },
-  "files": ["dist"],
+  "files": ["dist", "LICENSE", "README.md"],
   "scripts": {
     "build": "tsup src/index.ts --format esm,cjs,iife --global-name DooIconikAlpine --dts"
   },
   "dependencies": {
-    "@doo-iconik/core": "file:../core"
+    "@ajentik/doo-iconik": "file:../core"
   },
   "peerDependencies": {
     "alpinejs": "^3.0.0"

--- a/packages/alpine/src/index.ts
+++ b/packages/alpine/src/index.ts
@@ -1,6 +1,6 @@
 import type { Alpine as AlpineType } from 'alpinejs';
-import { iconData, resolveSize, buildTransform, buildAnimationClasses, buildVariantClass, animationCSS, escapeAttr } from '@doo-iconik/core';
-import type { DooIconikName, DooIconikSize, DooIconikVariant, DooIconikAnimation } from '@doo-iconik/core';
+import { iconData, resolveSize, buildTransform, buildAnimationClasses, buildVariantClass, animationCSS, escapeAttr } from '@ajentik/doo-iconik';
+import type { DooIconikName, DooIconikSize, DooIconikVariant, DooIconikAnimation } from '@ajentik/doo-iconik';
 
 // Inject animation styles once
 function injectStyles() {
@@ -118,5 +118,5 @@ export default function dooIconikPlugin(Alpine: AlpineType) {
 }
 
 // Re-export for convenience
-export { iconData, resolveSize } from '@doo-iconik/core';
-export type { DooIconikName, DooIconikSize, DooIconikCategory, DooIconikVariant, DooIconikAnimation, IconData } from '@doo-iconik/core';
+export { iconData, resolveSize } from '@ajentik/doo-iconik';
+export type { DooIconikName, DooIconikSize, DooIconikCategory, DooIconikVariant, DooIconikAnimation, IconData } from '@ajentik/doo-iconik';

--- a/packages/angular/LICENSE
+++ b/packages/angular/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Ajentik
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/angular/README.md
+++ b/packages/angular/README.md
@@ -1,6 +1,6 @@
-# @doo-iconik/angular
+# @ajentik/doo-iconik-angular
 
-[![npm version](https://img.shields.io/npm/v/@doo-iconik/angular.svg)](https://www.npmjs.com/package/@doo-iconik/angular)
+[![npm version](https://img.shields.io/npm/v/@ajentik/doo-iconik-angular.svg)](https://www.npmjs.com/package/@ajentik/doo-iconik-angular)
 
 Angular component library: 595 hand-drawn doodle-style SVG icons for Angular 16+.
 
@@ -9,13 +9,13 @@ Part of [doo-iconik](https://github.com/ajentik/doo-iconik).
 ## Install
 
 ```bash
-npm i @doo-iconik/angular
+npm i @ajentik/doo-iconik-angular
 ```
 
 ## Usage
 
 ```typescript
-import { DooIconikComponent } from '@doo-iconik/angular';
+import { DooIconikComponent } from '@ajentik/doo-iconik-angular';
 
 @Component({
   selector: 'app-root',

--- a/packages/angular/ng-package.json
+++ b/packages/angular/ng-package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../../node_modules/ng-packagr/ng-package.schema.json",
   "dest": "../../dist/angular",
-  "allowedNonPeerDependencies": ["@doo-iconik/core"],
+  "allowedNonPeerDependencies": ["@ajentik/doo-iconik"],
   "lib": {
     "entryFile": "src/public-api.ts"
   }

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@doo-iconik/angular",
+  "name": "@ajentik/doo-iconik-angular",
   "version": "1.0.0",
   "description": "Angular component adapter for doo-iconik hand-drawn icons",
   "license": "MIT",
@@ -9,12 +9,12 @@
     "url": "https://github.com/ajentik/doo-iconik/issues"
   },
   "sideEffects": false,
-  "files": ["dist"],
+  "files": ["dist", "LICENSE", "README.md"],
   "scripts": {
     "build": "ng-packagr -p ng-package.json"
   },
   "dependencies": {
-    "@doo-iconik/core": "file:../core"
+    "@ajentik/doo-iconik": "file:../core"
   },
   "peerDependencies": {
     "@angular/core": ">=16.0.0",

--- a/packages/angular/src/doo-iconik.component.ts
+++ b/packages/angular/src/doo-iconik.component.ts
@@ -1,8 +1,8 @@
 import { Component, Input, OnInit, OnChanges } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
-import { iconData, resolveSize, buildTransform, buildAnimationClasses, buildVariantClass, animationCSS, escapeAttr } from '@doo-iconik/core';
-import type { DooIconikName, DooIconikSize, DooIconikVariant, DooIconikAnimation } from '@doo-iconik/core';
+import { iconData, resolveSize, buildTransform, buildAnimationClasses, buildVariantClass, animationCSS, escapeAttr } from '@ajentik/doo-iconik';
+import type { DooIconikName, DooIconikSize, DooIconikVariant, DooIconikAnimation } from '@ajentik/doo-iconik';
 
 @Component({
   selector: 'doo-iconik',

--- a/packages/angular/src/index.ts
+++ b/packages/angular/src/index.ts
@@ -1,2 +1,2 @@
 export { DooIconikComponent } from './doo-iconik.component';
-export type { DooIconikName, DooIconikSize, DooIconikCategory, DooIconikVariant, DooIconikAnimation, IconData } from '@doo-iconik/core';
+export type { DooIconikName, DooIconikSize, DooIconikCategory, DooIconikVariant, DooIconikAnimation, IconData } from '@ajentik/doo-iconik';

--- a/packages/angular/src/public-api.ts
+++ b/packages/angular/src/public-api.ts
@@ -1,2 +1,2 @@
 export { DooIconikComponent } from './doo-iconik.component';
-export type { DooIconikName, DooIconikSize, DooIconikCategory, DooIconikVariant, DooIconikAnimation, IconData } from '@doo-iconik/core';
+export type { DooIconikName, DooIconikSize, DooIconikCategory, DooIconikVariant, DooIconikAnimation, IconData } from '@ajentik/doo-iconik';

--- a/packages/angular/tsconfig.json
+++ b/packages/angular/tsconfig.json
@@ -21,7 +21,7 @@
     "baseUrl": ".",
     "outDir": "./dist",
     "paths": {
-      "@doo-iconik/core": ["../core/src/index.ts"]
+      "@ajentik/doo-iconik": ["../core/src/index.ts"]
     }
   },
   "include": ["src/**/*.ts"],

--- a/packages/astro/LICENSE
+++ b/packages/astro/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Ajentik
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/astro/README.md
+++ b/packages/astro/README.md
@@ -1,6 +1,6 @@
-# @doo-iconik/astro
+# @ajentik/doo-iconik-astro
 
-[![npm version](https://img.shields.io/npm/v/@doo-iconik/astro.svg)](https://www.npmjs.com/package/@doo-iconik/astro)
+[![npm version](https://img.shields.io/npm/v/@ajentik/doo-iconik-astro.svg)](https://www.npmjs.com/package/@ajentik/doo-iconik-astro)
 
 Astro component library: 595 hand-drawn doodle-style SVG icons for Astro 3/4.
 
@@ -9,14 +9,14 @@ Part of [doo-iconik](https://github.com/ajentik/doo-iconik).
 ## Install
 
 ```bash
-npm i @doo-iconik/astro
+npm i @ajentik/doo-iconik-astro
 ```
 
 ## Usage
 
 ```astro
 ---
-import { DooIconik } from '@doo-iconik/astro';
+import { DooIconik } from '@ajentik/doo-iconik-astro';
 ---
 
 <DooIconik name="heart" size="lg" />

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@doo-iconik/astro",
+  "name": "@ajentik/doo-iconik-astro",
   "version": "1.0.0",
   "description": "Astro component for doo-iconik hand-drawn icons",
   "license": "MIT",
@@ -17,9 +17,9 @@
   "scripts": {
     "build": "echo 'Astro package ships source — no build needed'"
   },
-  "files": ["src"],
+  "files": ["src", "LICENSE", "README.md"],
   "dependencies": {
-    "@doo-iconik/core": "file:../core"
+    "@ajentik/doo-iconik": "file:../core"
   },
   "peerDependencies": {
     "astro": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0"

--- a/packages/astro/src/DooIconik.astro
+++ b/packages/astro/src/DooIconik.astro
@@ -1,6 +1,6 @@
 ---
-import type { DooIconikName, DooIconikSize, DooIconikVariant, DooIconikAnimation } from '@doo-iconik/core';
-import { iconData, resolveSize, buildTransform, buildAnimationClasses, buildVariantClass, animationCSS } from '@doo-iconik/core';
+import type { DooIconikName, DooIconikSize, DooIconikVariant, DooIconikAnimation } from '@ajentik/doo-iconik';
+import { iconData, resolveSize, buildTransform, buildAnimationClasses, buildVariantClass, animationCSS } from '@ajentik/doo-iconik';
 
 interface Props {
   name: DooIconikName;

--- a/packages/astro/src/index.ts
+++ b/packages/astro/src/index.ts
@@ -1,3 +1,3 @@
 export { default as DooIconik } from './DooIconik.astro';
-export type { DooIconikName, DooIconikSize, DooIconikCategory, DooIconikVariant, DooIconikAnimation, IconData } from '@doo-iconik/core';
-export { iconData } from '@doo-iconik/core';
+export type { DooIconikName, DooIconikSize, DooIconikCategory, DooIconikVariant, DooIconikAnimation, IconData } from '@ajentik/doo-iconik';
+export { iconData } from '@ajentik/doo-iconik';

--- a/packages/core/LICENSE
+++ b/packages/core/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Ajentik
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,6 +1,6 @@
-# @doo-iconik/core
+# @ajentik/doo-iconik
 
-[![npm version](https://img.shields.io/npm/v/@doo-iconik/core.svg)](https://www.npmjs.com/package/@doo-iconik/core)
+[![npm version](https://img.shields.io/npm/v/@ajentik/doo-iconik.svg)](https://www.npmjs.com/package/@ajentik/doo-iconik)
 
 Framework-agnostic shared icon data and utilities: 595 hand-drawn doodle-style SVG icons.
 
@@ -9,13 +9,13 @@ Part of [doo-iconik](https://github.com/ajentik/doo-iconik).
 ## Install
 
 ```bash
-npm i @doo-iconik/core
+npm i @ajentik/doo-iconik
 ```
 
 ## Usage
 
 ```js
-import { getIcon, getAllIconNames } from '@doo-iconik/core';
+import { getIcon, getAllIconNames } from '@ajentik/doo-iconik';
 
 // Get a single icon's SVG data
 const heart = getIcon('heart');
@@ -35,7 +35,7 @@ const names = getAllIconNames();
 
 ## Props
 
-All framework wrappers built on `@doo-iconik/core` accept: `name`, `size`, `spin`, `pulse`, `bounce`, `flipHorizontal`, `flipVertical`, `variant`, `animation`.
+All framework wrappers built on `@ajentik/doo-iconik` accept: `name`, `size`, `spin`, `pulse`, `bounce`, `flipHorizontal`, `flipVertical`, `variant`, `animation`.
 
 See the [main documentation](https://github.com/ajentik/doo-iconik#props) for full prop details.
 
@@ -45,10 +45,10 @@ Import individual icons for smaller bundles:
 
 ```typescript
 // Only bundles the heart icon (~200 bytes)
-import { heart } from '@doo-iconik/core/icons/heart';
+import { heart } from '@ajentik/doo-iconik/icons/heart';
 
 // All icons (~212KB)
-import { iconData } from '@doo-iconik/core';
+import { iconData } from '@ajentik/doo-iconik';
 ```
 
 ## License

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@doo-iconik/core",
+  "name": "@ajentik/doo-iconik",
   "version": "1.0.0",
   "description": "Framework-agnostic core icon data and utilities for doo-iconik",
   "license": "MIT",
@@ -44,7 +44,7 @@
       "default": "./dist/icons/index.js"
     }
   },
-  "files": ["dist"],
+  "files": ["dist", "LICENSE", "README.md"],
   "scripts": {
     "build": "tsc -p tsconfig.json"
   },

--- a/packages/flutter/LICENSE
+++ b/packages/flutter/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Ajentik
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/laravel/LICENSE
+++ b/packages/laravel/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Ajentik
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/lit/LICENSE
+++ b/packages/lit/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Ajentik
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/lit/README.md
+++ b/packages/lit/README.md
@@ -1,6 +1,6 @@
-# @doo-iconik/lit
+# @ajentik/doo-iconik-lit
 
-[![npm version](https://img.shields.io/npm/v/@doo-iconik/lit.svg)](https://www.npmjs.com/package/@doo-iconik/lit)
+[![npm version](https://img.shields.io/npm/v/@ajentik/doo-iconik-lit.svg)](https://www.npmjs.com/package/@ajentik/doo-iconik-lit)
 
 Lit web component: 595 hand-drawn doodle-style SVG icons for Lit 3.
 
@@ -9,13 +9,13 @@ Part of [doo-iconik](https://github.com/ajentik/doo-iconik).
 ## Install
 
 ```bash
-npm i @doo-iconik/lit
+npm i @ajentik/doo-iconik-lit
 ```
 
 ## Usage
 
 ```js
-import '@doo-iconik/lit';
+import '@ajentik/doo-iconik-lit';
 ```
 
 ```html

--- a/packages/lit/package.json
+++ b/packages/lit/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@doo-iconik/lit",
+  "name": "@ajentik/doo-iconik-lit",
   "version": "1.0.0",
   "description": "Lit adapter (Web Component) for doo-iconik icons",
   "license": "MIT",
@@ -20,12 +20,12 @@
       "require": "./dist/index.cjs"
     }
   },
-  "files": ["dist"],
+  "files": ["dist", "LICENSE", "README.md"],
   "scripts": {
     "build": "tsup src/index.ts --format esm,cjs --dts"
   },
   "dependencies": {
-    "@doo-iconik/core": "file:../core"
+    "@ajentik/doo-iconik": "file:../core"
   },
   "peerDependencies": {
     "lit": "^3.0.0"

--- a/packages/lit/src/DooIconik.ts
+++ b/packages/lit/src/DooIconik.ts
@@ -1,7 +1,7 @@
 import { LitElement, html, css, svg, nothing } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
-import { iconData, resolveSize, buildTransform, buildAnimationClasses, buildVariantClass } from '@doo-iconik/core';
-import type { DooIconikName, DooIconikSize, DooIconikVariant, DooIconikAnimation } from '@doo-iconik/core';
+import { iconData, resolveSize, buildTransform, buildAnimationClasses, buildVariantClass } from '@ajentik/doo-iconik';
+import type { DooIconikName, DooIconikSize, DooIconikVariant, DooIconikAnimation } from '@ajentik/doo-iconik';
 
 @customElement('doo-iconik-lit')
 export class DooIconikElement extends LitElement {

--- a/packages/lit/src/index.ts
+++ b/packages/lit/src/index.ts
@@ -1,2 +1,2 @@
 export { DooIconikElement } from './DooIconik.js';
-export type { DooIconikName, DooIconikSize, DooIconikCategory, DooIconikVariant, DooIconikAnimation, IconData } from '@doo-iconik/core';
+export type { DooIconikName, DooIconikSize, DooIconikCategory, DooIconikVariant, DooIconikAnimation, IconData } from '@ajentik/doo-iconik';

--- a/packages/preact/LICENSE
+++ b/packages/preact/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Ajentik
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/preact/README.md
+++ b/packages/preact/README.md
@@ -1,6 +1,6 @@
-# @doo-iconik/preact
+# @ajentik/doo-iconik-preact
 
-[![npm version](https://img.shields.io/npm/v/@doo-iconik/preact.svg)](https://www.npmjs.com/package/@doo-iconik/preact)
+[![npm version](https://img.shields.io/npm/v/@ajentik/doo-iconik-preact.svg)](https://www.npmjs.com/package/@ajentik/doo-iconik-preact)
 
 Preact component library: 595 hand-drawn doodle-style SVG icons for Preact 10.
 
@@ -9,13 +9,13 @@ Part of [doo-iconik](https://github.com/ajentik/doo-iconik).
 ## Install
 
 ```bash
-npm i @doo-iconik/preact
+npm i @ajentik/doo-iconik-preact
 ```
 
 ## Usage
 
 ```jsx
-import { DooIconik } from '@doo-iconik/preact';
+import { DooIconik } from '@ajentik/doo-iconik-preact';
 
 function App() {
   return (

--- a/packages/preact/package.json
+++ b/packages/preact/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@doo-iconik/preact",
+  "name": "@ajentik/doo-iconik-preact",
   "version": "1.0.0",
   "description": "Preact component for doo-iconik hand-drawn icons",
   "license": "MIT",
@@ -21,12 +21,12 @@
       "default": "./dist/index.mjs"
     }
   },
-  "files": ["dist"],
+  "files": ["dist", "LICENSE", "README.md"],
   "scripts": {
     "build": "tsup src/index.tsx --format esm,cjs --dts"
   },
   "dependencies": {
-    "@doo-iconik/core": "file:../core"
+    "@ajentik/doo-iconik": "file:../core"
   },
   "peerDependencies": {
     "preact": "^10.0.0"

--- a/packages/preact/src/DooIconik.tsx
+++ b/packages/preact/src/DooIconik.tsx
@@ -1,7 +1,7 @@
 import { h, FunctionComponent } from 'preact';
 import { useEffect } from 'preact/hooks';
-import { iconData, resolveSize, buildTransform, buildAnimationClasses, buildVariantClass, animationCSS } from '@doo-iconik/core';
-import type { DooIconikName, DooIconikSize, DooIconikVariant, DooIconikAnimation } from '@doo-iconik/core';
+import { iconData, resolveSize, buildTransform, buildAnimationClasses, buildVariantClass, animationCSS } from '@ajentik/doo-iconik';
+import type { DooIconikName, DooIconikSize, DooIconikVariant, DooIconikAnimation } from '@ajentik/doo-iconik';
 import type { JSX } from 'preact';
 
 export interface DooIconikProps extends Omit<JSX.SVGAttributes<SVGSVGElement>, 'size'> {

--- a/packages/preact/src/index.tsx
+++ b/packages/preact/src/index.tsx
@@ -1,3 +1,3 @@
 export { DooIconik } from './DooIconik';
 export type { DooIconikProps } from './DooIconik';
-export type { DooIconikName, DooIconikSize, DooIconikCategory, DooIconikVariant, DooIconikAnimation, IconData } from '@doo-iconik/core';
+export type { DooIconikName, DooIconikSize, DooIconikCategory, DooIconikVariant, DooIconikAnimation, IconData } from '@ajentik/doo-iconik';

--- a/packages/qwik/LICENSE
+++ b/packages/qwik/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Ajentik
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/qwik/README.md
+++ b/packages/qwik/README.md
@@ -1,6 +1,6 @@
-# @doo-iconik/qwik
+# @ajentik/doo-iconik-qwik
 
-[![npm version](https://img.shields.io/npm/v/@doo-iconik/qwik.svg)](https://www.npmjs.com/package/@doo-iconik/qwik)
+[![npm version](https://img.shields.io/npm/v/@ajentik/doo-iconik-qwik.svg)](https://www.npmjs.com/package/@ajentik/doo-iconik-qwik)
 
 Qwik component library: 595 hand-drawn doodle-style SVG icons for Qwik.
 
@@ -9,14 +9,14 @@ Part of [doo-iconik](https://github.com/ajentik/doo-iconik).
 ## Install
 
 ```bash
-npm i @doo-iconik/qwik
+npm i @ajentik/doo-iconik-qwik
 ```
 
 ## Usage
 
 ```tsx
 import { component$ } from '@builder.io/qwik';
-import { DooIconik } from '@doo-iconik/qwik';
+import { DooIconik } from '@ajentik/doo-iconik-qwik';
 
 export default component$(() => {
   return (

--- a/packages/qwik/package.json
+++ b/packages/qwik/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@doo-iconik/qwik",
+  "name": "@ajentik/doo-iconik-qwik",
   "version": "1.0.0",
   "description": "Qwik component for doo-iconik hand-drawn icons",
   "license": "MIT",
@@ -21,12 +21,12 @@
       "default": "./dist/index.mjs"
     }
   },
-  "files": ["dist"],
+  "files": ["dist", "LICENSE", "README.md"],
   "scripts": {
     "build": "tsup src/index.tsx --format esm,cjs --dts --external @builder.io/qwik"
   },
   "dependencies": {
-    "@doo-iconik/core": "file:../core"
+    "@ajentik/doo-iconik": "file:../core"
   },
   "peerDependencies": {
     "@builder.io/qwik": "^1.5.0 || ^2.0.0"

--- a/packages/qwik/src/DooIconik.tsx
+++ b/packages/qwik/src/DooIconik.tsx
@@ -1,6 +1,6 @@
 import { component$, useVisibleTask$ } from '@builder.io/qwik';
-import { iconData, resolveSize, buildTransform, buildAnimationClasses, buildVariantClass, animationCSS } from '@doo-iconik/core';
-import type { DooIconikName, DooIconikSize, DooIconikVariant, DooIconikAnimation } from '@doo-iconik/core';
+import { iconData, resolveSize, buildTransform, buildAnimationClasses, buildVariantClass, animationCSS } from '@ajentik/doo-iconik';
+import type { DooIconikName, DooIconikSize, DooIconikVariant, DooIconikAnimation } from '@ajentik/doo-iconik';
 
 interface DooIconikProps {
   name: DooIconikName;

--- a/packages/qwik/src/index.tsx
+++ b/packages/qwik/src/index.tsx
@@ -1,2 +1,2 @@
 export { DooIconik } from './DooIconik';
-export type { DooIconikName, DooIconikSize, DooIconikCategory, DooIconikVariant, DooIconikAnimation, IconData } from '@doo-iconik/core';
+export type { DooIconikName, DooIconikSize, DooIconikCategory, DooIconikVariant, DooIconikAnimation, IconData } from '@ajentik/doo-iconik';

--- a/packages/rails/LICENSE
+++ b/packages/rails/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Ajentik
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/react/LICENSE
+++ b/packages/react/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Ajentik
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -1,6 +1,6 @@
-# @doo-iconik/react
+# @ajentik/doo-iconik-react
 
-[![npm version](https://img.shields.io/npm/v/@doo-iconik/react.svg)](https://www.npmjs.com/package/@doo-iconik/react)
+[![npm version](https://img.shields.io/npm/v/@ajentik/doo-iconik-react.svg)](https://www.npmjs.com/package/@ajentik/doo-iconik-react)
 
 React component library: 595 hand-drawn doodle-style SVG icons for React 18/19.
 
@@ -9,13 +9,13 @@ Part of [doo-iconik](https://github.com/ajentik/doo-iconik).
 ## Install
 
 ```bash
-npm i @doo-iconik/react
+npm i @ajentik/doo-iconik-react
 ```
 
 ## Usage
 
 ```jsx
-import { DooIconik } from '@doo-iconik/react';
+import { DooIconik } from '@ajentik/doo-iconik-react';
 
 function App() {
   return (

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@doo-iconik/react",
+  "name": "@ajentik/doo-iconik-react",
   "version": "1.0.0",
   "description": "React component for doo-iconik hand-drawn icons",
   "license": "MIT",
@@ -21,14 +21,12 @@
       "default": "./dist/index.mjs"
     }
   },
-  "files": [
-    "dist"
-  ],
+  "files": ["dist", "LICENSE", "README.md"],
   "scripts": {
     "build": "tsup src/index.tsx --format esm,cjs --dts"
   },
   "dependencies": {
-    "@doo-iconik/core": "file:../core"
+    "@ajentik/doo-iconik": "file:../core"
   },
   "peerDependencies": {
     "react": "^18.0.0 || ^19.0.0",

--- a/packages/react/src/DooIconik.tsx
+++ b/packages/react/src/DooIconik.tsx
@@ -6,8 +6,8 @@ import {
   buildAnimationClasses,
   buildVariantClass,
   animationCSS,
-} from '@doo-iconik/core';
-import type { DooIconikName, DooIconikSize, DooIconikVariant, DooIconikAnimation } from '@doo-iconik/core';
+} from '@ajentik/doo-iconik';
+import type { DooIconikName, DooIconikSize, DooIconikVariant, DooIconikAnimation } from '@ajentik/doo-iconik';
 
 let cssInjected = false;
 

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -1,3 +1,3 @@
 export { DooIconik } from './DooIconik';
 export type { DooIconikProps } from './DooIconik';
-export type { DooIconikName, DooIconikSize, DooIconikCategory, DooIconikVariant, DooIconikAnimation, IconData } from '@doo-iconik/core';
+export type { DooIconikName, DooIconikSize, DooIconikCategory, DooIconikVariant, DooIconikAnimation, IconData } from '@ajentik/doo-iconik';

--- a/packages/react/vitest.config.ts
+++ b/packages/react/vitest.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   resolve: {
     alias: [
       {
-        find: '@doo-iconik/core',
+        find: '@ajentik/doo-iconik',
         replacement: path.resolve(__dirname, '../core/src/index.ts'),
       },
     ],

--- a/packages/solid/LICENSE
+++ b/packages/solid/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Ajentik
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/solid/README.md
+++ b/packages/solid/README.md
@@ -1,6 +1,6 @@
-# @doo-iconik/solid
+# @ajentik/doo-iconik-solid
 
-[![npm version](https://img.shields.io/npm/v/@doo-iconik/solid.svg)](https://www.npmjs.com/package/@doo-iconik/solid)
+[![npm version](https://img.shields.io/npm/v/@ajentik/doo-iconik-solid.svg)](https://www.npmjs.com/package/@ajentik/doo-iconik-solid)
 
 SolidJS component library: 595 hand-drawn doodle-style SVG icons for SolidJS.
 
@@ -9,13 +9,13 @@ Part of [doo-iconik](https://github.com/ajentik/doo-iconik).
 ## Install
 
 ```bash
-npm i @doo-iconik/solid
+npm i @ajentik/doo-iconik-solid
 ```
 
 ## Usage
 
 ```jsx
-import { DooIconik } from '@doo-iconik/solid';
+import { DooIconik } from '@ajentik/doo-iconik-solid';
 
 function App() {
   return (

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@doo-iconik/solid",
+  "name": "@ajentik/doo-iconik-solid",
   "version": "1.0.0",
   "description": "SolidJS component for doo-iconik hand-drawn icons",
   "license": "MIT",
@@ -21,12 +21,12 @@
       "default": "./dist/index.mjs"
     }
   },
-  "files": ["dist"],
+  "files": ["dist", "LICENSE", "README.md"],
   "scripts": {
     "build": "tsup src/index.tsx --format esm,cjs --dts"
   },
   "dependencies": {
-    "@doo-iconik/core": "file:../core"
+    "@ajentik/doo-iconik": "file:../core"
   },
   "peerDependencies": {
     "solid-js": "^1.7.0"

--- a/packages/solid/src/DooIconik.tsx
+++ b/packages/solid/src/DooIconik.tsx
@@ -1,7 +1,7 @@
 import { Component, createMemo, onMount, splitProps, JSX } from 'solid-js';
 import { For, Show } from 'solid-js/web';
-import { iconData, resolveSize, buildTransform, buildAnimationClasses, buildVariantClass, animationCSS } from '@doo-iconik/core';
-import type { DooIconikName, DooIconikSize, DooIconikVariant, DooIconikAnimation } from '@doo-iconik/core';
+import { iconData, resolveSize, buildTransform, buildAnimationClasses, buildVariantClass, animationCSS } from '@ajentik/doo-iconik';
+import type { DooIconikName, DooIconikSize, DooIconikVariant, DooIconikAnimation } from '@ajentik/doo-iconik';
 
 export interface DooIconikProps extends JSX.SvgSVGAttributes<SVGSVGElement> {
   name: DooIconikName;

--- a/packages/solid/src/index.tsx
+++ b/packages/solid/src/index.tsx
@@ -1,3 +1,3 @@
 export { DooIconik } from './DooIconik';
 export type { DooIconikProps } from './DooIconik';
-export type { DooIconikName, DooIconikSize, DooIconikCategory, DooIconikVariant, DooIconikAnimation, IconData } from '@doo-iconik/core';
+export type { DooIconikName, DooIconikSize, DooIconikCategory, DooIconikVariant, DooIconikAnimation, IconData } from '@ajentik/doo-iconik';

--- a/packages/svelte/LICENSE
+++ b/packages/svelte/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Ajentik
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -1,6 +1,6 @@
-# @doo-iconik/svelte
+# @ajentik/doo-iconik-svelte
 
-[![npm version](https://img.shields.io/npm/v/@doo-iconik/svelte.svg)](https://www.npmjs.com/package/@doo-iconik/svelte)
+[![npm version](https://img.shields.io/npm/v/@ajentik/doo-iconik-svelte.svg)](https://www.npmjs.com/package/@ajentik/doo-iconik-svelte)
 
 Svelte component library: 595 hand-drawn doodle-style SVG icons for Svelte 5.
 
@@ -9,14 +9,14 @@ Part of [doo-iconik](https://github.com/ajentik/doo-iconik).
 ## Install
 
 ```bash
-npm i @doo-iconik/svelte
+npm i @ajentik/doo-iconik-svelte
 ```
 
 ## Usage
 
 ```svelte
 <script>
-  import { DooIconik } from '@doo-iconik/svelte';
+  import { DooIconik } from '@ajentik/doo-iconik-svelte';
 </script>
 
 <DooIconik name="heart" size="lg" />

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@doo-iconik/svelte",
+  "name": "@ajentik/doo-iconik-svelte",
   "version": "1.0.0",
   "description": "Svelte component for doo-iconik hand-drawn icons",
   "license": "MIT",
@@ -21,12 +21,12 @@
       "default": "./dist/index.js"
     }
   },
-  "files": ["dist"],
+  "files": ["dist", "LICENSE", "README.md"],
   "scripts": {
     "build": "svelte-package -i src -o dist"
   },
   "dependencies": {
-    "@doo-iconik/core": "file:../core"
+    "@ajentik/doo-iconik": "file:../core"
   },
   "peerDependencies": {
     "svelte": "^5.0.0"

--- a/packages/svelte/src/DooIconik.svelte
+++ b/packages/svelte/src/DooIconik.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import type { DooIconikName, DooIconikSize, DooIconikVariant, DooIconikAnimation } from '@doo-iconik/core';
-  import { iconData, resolveSize, buildTransform, buildAnimationClasses, buildVariantClass } from '@doo-iconik/core';
+  import type { DooIconikName, DooIconikSize, DooIconikVariant, DooIconikAnimation } from '@ajentik/doo-iconik';
+  import { iconData, resolveSize, buildTransform, buildAnimationClasses, buildVariantClass } from '@ajentik/doo-iconik';
 
   interface Props {
     name: DooIconikName;

--- a/packages/svelte/src/index.ts
+++ b/packages/svelte/src/index.ts
@@ -1,3 +1,3 @@
 export { default as DooIconik } from './DooIconik.svelte';
-export type { DooIconikName, DooIconikSize, DooIconikCategory, DooIconikVariant, DooIconikAnimation, IconData } from '@doo-iconik/core';
-export { iconData } from '@doo-iconik/core';
+export type { DooIconikName, DooIconikSize, DooIconikCategory, DooIconikVariant, DooIconikAnimation, IconData } from '@ajentik/doo-iconik';
+export { iconData } from '@ajentik/doo-iconik';

--- a/packages/vanilla/LICENSE
+++ b/packages/vanilla/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Ajentik
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/vanilla/README.md
+++ b/packages/vanilla/README.md
@@ -1,6 +1,6 @@
-# @doo-iconik/vanilla
+# @ajentik/doo-iconik-vanilla
 
-[![npm version](https://img.shields.io/npm/v/@doo-iconik/vanilla.svg)](https://www.npmjs.com/package/@doo-iconik/vanilla)
+[![npm version](https://img.shields.io/npm/v/@ajentik/doo-iconik-vanilla.svg)](https://www.npmjs.com/package/@ajentik/doo-iconik-vanilla)
 
 Vanilla JS / Web Components: 595 hand-drawn doodle-style SVG icons for Vanilla JS.
 
@@ -9,7 +9,7 @@ Part of [doo-iconik](https://github.com/ajentik/doo-iconik).
 ## Install
 
 ```bash
-npm i @doo-iconik/vanilla
+npm i @ajentik/doo-iconik-vanilla
 ```
 
 ## Usage
@@ -17,7 +17,7 @@ npm i @doo-iconik/vanilla
 ### Web Component
 
 ```js
-import { register } from '@doo-iconik/vanilla';
+import { register } from '@ajentik/doo-iconik-vanilla';
 
 // Register the <doo-iconik> custom element
 register();
@@ -31,7 +31,7 @@ register();
 ### Programmatic API
 
 ```js
-import { createIcon } from '@doo-iconik/vanilla';
+import { createIcon } from '@ajentik/doo-iconik-vanilla';
 
 const icon = createIcon('heart', { size: 'lg', spin: true });
 document.body.appendChild(icon);

--- a/packages/vanilla/package.json
+++ b/packages/vanilla/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@doo-iconik/vanilla",
+  "name": "@ajentik/doo-iconik-vanilla",
   "version": "1.0.0",
   "description": "Vanilla JavaScript adapter (Web Component + createIcon) for doo-iconik icons",
   "license": "MIT",
@@ -20,12 +20,12 @@
       "require": "./dist/index.cjs"
     }
   },
-  "files": ["dist"],
+  "files": ["dist", "LICENSE", "README.md"],
   "scripts": {
     "build": "tsup src/index.ts --format esm,cjs,iife --global-name DooIconik --dts"
   },
   "dependencies": {
-    "@doo-iconik/core": "file:../core"
+    "@ajentik/doo-iconik": "file:../core"
   },
   "devDependencies": {
     "tsup": "^8.0.0",

--- a/packages/vanilla/src/DooIconik.ts
+++ b/packages/vanilla/src/DooIconik.ts
@@ -1,5 +1,5 @@
-import { iconData, resolveSize, buildTransform, buildAnimationClasses, buildVariantClass, animationCSS, escapeAttr } from '@doo-iconik/core';
-import type { DooIconikName, DooIconikSize, DooIconikVariant, DooIconikAnimation } from '@doo-iconik/core';
+import { iconData, resolveSize, buildTransform, buildAnimationClasses, buildVariantClass, animationCSS, escapeAttr } from '@ajentik/doo-iconik';
+import type { DooIconikName, DooIconikSize, DooIconikVariant, DooIconikAnimation } from '@ajentik/doo-iconik';
 
 export class DooIconikElement extends HTMLElement {
   static get observedAttributes() {

--- a/packages/vanilla/src/index.ts
+++ b/packages/vanilla/src/index.ts
@@ -1,11 +1,11 @@
-import { iconData, resolveSize, buildTransform, buildAnimationClasses, buildVariantClass, animationCSS } from '@doo-iconik/core';
-import type { DooIconikName, DooIconikSize, DooIconikVariant, DooIconikAnimation } from '@doo-iconik/core';
+import { iconData, resolveSize, buildTransform, buildAnimationClasses, buildVariantClass, animationCSS } from '@ajentik/doo-iconik';
+import type { DooIconikName, DooIconikSize, DooIconikVariant, DooIconikAnimation } from '@ajentik/doo-iconik';
 import { DooIconikElement } from './DooIconik.js';
 
 export { DooIconikElement } from './DooIconik.js';
 
-export type { DooIconikName, DooIconikSize, DooIconikCategory, DooIconikVariant, DooIconikAnimation, IconData } from '@doo-iconik/core';
-export { iconData, sizeMap, resolveSize, buildTransform, buildAnimationClasses, buildVariantClass, animationCSS, escapeAttr } from '@doo-iconik/core';
+export type { DooIconikName, DooIconikSize, DooIconikCategory, DooIconikVariant, DooIconikAnimation, IconData } from '@ajentik/doo-iconik';
+export { iconData, sizeMap, resolveSize, buildTransform, buildAnimationClasses, buildVariantClass, animationCSS, escapeAttr } from '@ajentik/doo-iconik';
 
 /**
  * Register the `<doo-iconik>` custom element.

--- a/packages/vue/LICENSE
+++ b/packages/vue/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Ajentik
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -1,6 +1,6 @@
-# @doo-iconik/vue
+# @ajentik/doo-iconik-vue
 
-[![npm version](https://img.shields.io/npm/v/@doo-iconik/vue.svg)](https://www.npmjs.com/package/@doo-iconik/vue)
+[![npm version](https://img.shields.io/npm/v/@ajentik/doo-iconik-vue.svg)](https://www.npmjs.com/package/@ajentik/doo-iconik-vue)
 
 Vue component library: 595 hand-drawn doodle-style SVG icons for Vue 3.
 
@@ -9,14 +9,14 @@ Part of [doo-iconik](https://github.com/ajentik/doo-iconik).
 ## Install
 
 ```bash
-npm i @doo-iconik/vue
+npm i @ajentik/doo-iconik-vue
 ```
 
 ## Usage
 
 ```vue
 <script setup>
-import { DooIconik } from '@doo-iconik/vue';
+import { DooIconik } from '@ajentik/doo-iconik-vue';
 </script>
 
 <template>

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@doo-iconik/vue",
+  "name": "@ajentik/doo-iconik-vue",
   "version": "1.0.0",
   "description": "Vue 3 component adapter for doo-iconik icons",
   "license": "MIT",
@@ -17,12 +17,12 @@
     ".": "./src/index.ts",
     "./DooIconik.vue": "./src/DooIconik.vue"
   },
-  "files": ["src"],
+  "files": ["src", "LICENSE", "README.md"],
   "scripts": {
     "build": "echo 'Vue package ships source — no build needed'"
   },
   "dependencies": {
-    "@doo-iconik/core": "file:../core"
+    "@ajentik/doo-iconik": "file:../core"
   },
   "peerDependencies": {
     "vue": "^3.3.0"

--- a/packages/vue/src/DooIconik.vue
+++ b/packages/vue/src/DooIconik.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, onMounted } from 'vue';
-import { iconData, resolveSize, buildTransform, buildAnimationClasses, buildVariantClass, animationCSS } from '@doo-iconik/core';
-import type { DooIconikName, DooIconikSize, DooIconikVariant, DooIconikAnimation } from '@doo-iconik/core';
+import { iconData, resolveSize, buildTransform, buildAnimationClasses, buildVariantClass, animationCSS } from '@ajentik/doo-iconik';
+import type { DooIconikName, DooIconikSize, DooIconikVariant, DooIconikAnimation } from '@ajentik/doo-iconik';
 
 const props = withDefaults(defineProps<{
   name: DooIconikName;

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -1,2 +1,2 @@
 export { default as DooIconik } from './DooIconik.vue';
-export type { DooIconikName, DooIconikSize, DooIconikCategory, DooIconikVariant, DooIconikAnimation, IconData } from '@doo-iconik/core';
+export type { DooIconikName, DooIconikSize, DooIconikCategory, DooIconikVariant, DooIconikAnimation, IconData } from '@ajentik/doo-iconik';


### PR DESCRIPTION
Renames all 12 npm packages to publish under the existing @ajentik org. 63 files updated, 47 tests passing.