### PR TITLE
fix(cli): add @types/node and fix TS null-check errors in build

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -16,6 +16,7 @@
     "@ajentik/doo-iconik": "file:../core"
   },
   "devDependencies": {
+    "@types/node": "^22.0.0",
     "tsup": "^8.0.0",
     "typescript": "^5.0.0"
   },

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -138,17 +138,18 @@ function main() {
         console.error('Usage: doo-iconik info <name>');
         process.exit(1);
       }
-      const info = getInfo(name);
-      if (!info) {
+      const iconInfo = getInfo(name);
+      if (!iconInfo) {
         console.error(`Icon "${name}" not found.`);
         process.exit(1);
+        return;
       }
-      console.log(`Icon: ${info.name}`);
-      console.log(`  viewBox:    ${info.viewBox}`);
-      console.log(`  paths:      ${info.pathCount}`);
-      console.log(`  circles:    ${info.circleCount}`);
-      console.log(`  lines:      ${info.lineCount}`);
-      console.log(`  type:       ${info.type}`);
+      console.log(`Icon: ${iconInfo.name}`);
+      console.log(`  viewBox:    ${iconInfo.viewBox}`);
+      console.log(`  paths:      ${iconInfo.pathCount}`);
+      console.log(`  circles:    ${iconInfo.circleCount}`);
+      console.log(`  lines:      ${iconInfo.lineCount}`);
+      console.log(`  type:       ${iconInfo.type}`);
       break;
     }
 


### PR DESCRIPTION
Fixes CI failure from #54. The CLI package was missing `@types/node` (needed for `process.argv`/`process.exit`) and had a TS strict null-check issue with the `info` variable after `getInfo()`.